### PR TITLE
* 0.1.4 is hosted at the rxswiftcommunity github

### DIFF
--- a/RxGesture.podspec
+++ b/RxGesture.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RxGesture"
-  s.version          = "0.1.3"
+  s.version          = "0.1.4"
   s.summary          = "RxSwfit reactive wrapper for view gestures."
 
   s.description      = <<-DESC


### PR DESCRIPTION
bump pod version to promote the new remote url
