### PR TITLE
Use enums for gesture type + panning as example

### DIFF
--- a/Example/RxGesture-OSX/Base.lproj/Main.storyboard
+++ b/Example/RxGesture-OSX/Base.lproj/Main.storyboard
@@ -697,9 +697,25 @@
                             </textField>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="J7o-ag-sCE">
                                 <rect key="frame" x="252" y="154" width="100" height="100"/>
+                                <subviews>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PxO-V0-c9c">
+                                        <rect key="frame" x="-2" y="42" width="104" height="17"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="17" id="FJH-j3-NDm"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" id="0in-3i-hAG">
+                                            <font key="font" metaFont="systemSemibold" size="13"/>
+                                            <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </subviews>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="31T-Kj-b7X"/>
                                     <constraint firstAttribute="height" constant="100" id="SeR-Rt-Y3Z"/>
+                                    <constraint firstItem="PxO-V0-c9c" firstAttribute="centerY" secondItem="J7o-ag-sCE" secondAttribute="centerY" id="eNU-Lw-WWY"/>
+                                    <constraint firstItem="PxO-V0-c9c" firstAttribute="centerX" secondItem="J7o-ag-sCE" secondAttribute="centerX" id="sb5-0F-MGQ"/>
+                                    <constraint firstItem="PxO-V0-c9c" firstAttribute="width" secondItem="J7o-ag-sCE" secondAttribute="width" id="yLr-1i-cS1"/>
                                 </constraints>
                             </customView>
                         </subviews>
@@ -718,6 +734,7 @@
                         <outlet property="code" destination="5vr-DT-1jj" id="lmD-Bd-HuA"/>
                         <outlet property="info" destination="lTO-sj-z2M" id="PSu-ib-OjC"/>
                         <outlet property="myView" destination="J7o-ag-sCE" id="JSp-mW-x8x"/>
+                        <outlet property="myViewText" destination="PxO-V0-c9c" id="GTP-Pm-UmJ"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Example/RxGesture-OSX/ViewController.swift
+++ b/Example/RxGesture-OSX/ViewController.swift
@@ -17,18 +17,21 @@ class MacViewController: NSViewController {
     let infoList = [
         "Click the square",
         "Right click the square",
-        "Click any button (left or right)"
+        "Click any button (left or right)",
+        "Drag the square around"
     ]
     
     let codeList = [
         "myView.rx_gesture(.Click).subscribeNext {...}",
         "myView.rx_gesture(.RightClick).subscribeNext {...}",
-        "myView.rx_gesture(RxGestureTypeOptions.all()).subscribeNext {...}"
+        "myView.rx_gesture(RxGestureTypeOptions.all()).subscribeNext {...}",
+        "myView.rx_gesture([.Panning(.zero), .DidPan(.zero)]).subscribeNext {...}"
     ]
     
-    @IBOutlet var myView: NSView!
-    @IBOutlet var info: NSTextField!
-    @IBOutlet var code: NSTextField!
+    @IBOutlet weak var myView: NSView!
+    @IBOutlet weak var myViewText: NSTextField!
+    @IBOutlet weak var info: NSTextField!
+    @IBOutlet weak var code: NSTextField!
     
     private let nextStep😁 = PublishSubject<Void>()
     private let bag = DisposeBag()
@@ -45,7 +48,7 @@ class MacViewController: NSViewController {
         myView.layer?.cornerRadius = 5
         
         nextStep😁.scan(0, accumulator: {acc, _ in
-            return acc < 2 ? acc + 1 : 0
+            return acc < 3 ? acc + 1 : 0
         })
         .startWith(0)
         .subscribeNext(step)
@@ -81,6 +84,7 @@ class MacViewController: NSViewController {
                 self?.myView.layer!.transform = CATransform3DMakeScale(1.5, 1.5, 1.5)
 
                 let anim = CABasicAnimation(keyPath: "transform")
+                anim.duration = 0.5
                 anim.fromValue = NSValue(CATransform3D: CATransform3DIdentity)
                 anim.toValue = NSValue(CATransform3D: CATransform3DMakeScale(1.5, 1.5, 1.5))
                 self?.myView.layer!.addAnimation(anim, forKey: nil)
@@ -90,19 +94,41 @@ class MacViewController: NSViewController {
             }.addDisposableTo(stepBag)
             
         case 2: //any button
-            myView.rx_gesture(RxGestureTypeOptions.all()).subscribeNext {[weak self] _ in
-
+            myView.rx_gesture([.Click, .RightClick]).subscribeNext {[weak self] _ in
+                
                 self?.myView.layer!.transform = CATransform3DIdentity
                 self?.myView.layer!.backgroundColor = NSColor.redColor().CGColor
                 
                 let anim = CABasicAnimation(keyPath: "transform")
+                anim.duration = 0.5
                 anim.fromValue = NSValue(CATransform3D: CATransform3DMakeScale(1.5, 1.5, 1.5))
                 anim.toValue = NSValue(CATransform3D: CATransform3DIdentity)
                 self?.myView.layer!.addAnimation(anim, forKey: nil)
                 
                 self?.nextStep😁.onNext()
+            }.addDisposableTo(stepBag)
+            
+        case 3: //pan
+            myView.rx_gesture([.Panning(.zero), .DidPan(.zero)]).subscribeNext {[weak self] gesture in
                 
-                }.addDisposableTo(stepBag)
+                switch gesture {
+                case (.Panning(let offset)):
+                    self?.myViewText.stringValue = String(format: "(%.f, %.f)", arguments: [offset.x, offset.y])
+                    self?.myView.layer!.transform = CATransform3DMakeTranslation(offset.x, offset.y, 0.0)
+                case (.DidPan(_)):
+                    self?.myViewText.stringValue = ""
+                    
+                    let anim = CABasicAnimation(keyPath: "transform")
+                    anim.duration = 0.5
+                    anim.fromValue = NSValue(CATransform3D: self!.myView.layer!.transform)
+                    anim.toValue = NSValue(CATransform3D: CATransform3DIdentity)
+                    self?.myView.layer!.addAnimation(anim, forKey: nil)
+                    self?.myView.layer!.transform = CATransform3DIdentity
+                    
+                    self?.nextStep😁.onNext()
+                default: break
+                }
+            }.addDisposableTo(stepBag)
             
         default: break
         }

--- a/Example/RxGesture/Base.lproj/Main.storyboard
+++ b/Example/RxGesture/Base.lproj/Main.storyboard
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="RxGesture_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="RxGesture_iOS_Demo" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -35,10 +34,24 @@
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vUF-y6-oN7">
                                 <rect key="frame" x="260" y="110" width="80" height="80"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="BYX-hF-EJi">
+                                        <rect key="frame" x="0.0" y="30" width="80" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="21" id="MTs-3z-dIx"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" weight="thin" pointSize="21"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
                                 <color key="backgroundColor" red="1" green="0.25612482479941157" blue="0.29293124432128048" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="80" id="32A-6O-3fu"/>
+                                    <constraint firstItem="BYX-hF-EJi" firstAttribute="centerX" secondItem="vUF-y6-oN7" secondAttribute="centerX" id="480-zi-YbU"/>
                                     <constraint firstAttribute="width" constant="80" id="WaN-Xp-sQX"/>
+                                    <constraint firstItem="BYX-hF-EJi" firstAttribute="centerY" secondItem="vUF-y6-oN7" secondAttribute="centerY" id="XfE-O8-IMa"/>
+                                    <constraint firstItem="BYX-hF-EJi" firstAttribute="width" secondItem="vUF-y6-oN7" secondAttribute="width" id="g5i-az-CjO"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -64,6 +77,7 @@
                         <outlet property="code" destination="pAd-Nb-rmq" id="yQ7-1X-g4R"/>
                         <outlet property="info" destination="KuI-df-hG7" id="MRK-fq-iWl"/>
                         <outlet property="myView" destination="vUF-y6-oN7" id="RAX-Ab-eGd"/>
+                        <outlet property="myViewText" destination="BYX-hF-EJi" id="Eh6-97-9X6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>

--- a/Pod/Classes/OSX/NSView+RxGesture.swift
+++ b/Pod/Classes/OSX/NSView+RxGesture.swift
@@ -23,6 +23,14 @@ import RxCocoa
 
 extension NSView {
     
+    /// Shortcut to `rx_gesture` for when you need to subscribe to a single gesture
+    ///
+    /// - parameter type: RxGestureTypeOption value, e.g. `.Click` or `.Tap`
+    /// - returns: `ControlEvent<RxGestureTypeOption>` that emits any type one of the desired gestures is performed on the view
+    public func rx_gesture(type: RxGestureTypeOption) -> ControlEvent<RxGestureTypeOption> {
+        return rx_gesture([type])
+    }
+    
     /// Reactive wrapper for view gestures. You can observe a single gesture or multiple gestures
     /// (e.g. swipe left and right); the value the Observable emits is the type of the concrete gesture
     /// out of the list you are observing.
@@ -33,8 +41,8 @@ extension NSView {
     /// - seealso: `RxCocoa` adds `rx_tap` to `NSButton/UIButton` and is sufficient if you only need to subscribe
     ///   on taps on buttons. `RxGesture` on the other hand enables `userInteractionEnabled` and handles gestures on any view
 
-    public func rx_gesture(type: RxGestureTypeOptions) -> ControlEvent<RxGestureTypeOptions> {
-        let source: Observable<RxGestureTypeOptions> = Observable.create { [weak self] observer in
+    public func rx_gesture(type: [RxGestureTypeOption]) -> ControlEvent<RxGestureTypeOption> {
+        let source: Observable<RxGestureTypeOption> = Observable.create { [weak self] observer in
             MainScheduler.ensureExecutingOnScheduler()
             
             guard let control = self where !type.isEmpty else {
@@ -50,7 +58,7 @@ extension NSView {
                 click.buttonMask = 1 << 0
                 control.addGestureRecognizer(click)
                 gestures.append(
-                    click.rx_event.map {_ in RxGestureTypeOptions.Click}
+                    click.rx_event.map {_ in RxGestureTypeOption.Click}
                         .bindNext(observer.onNext)
                 )
             }
@@ -61,9 +69,71 @@ extension NSView {
                 click.buttonMask = 1 << 1
                 control.addGestureRecognizer(click)
                 gestures.append(
-                    click.rx_event.map {_ in RxGestureTypeOptions.RightClick}
+                    click.rx_event.map {_ in RxGestureTypeOption.RightClick}
                         .bindNext(observer.onNext)
                 )
+            }
+            
+            //panning
+            if type.contains(.Panning(.zero)) || type.contains(.DidPan(.zero)) {
+                
+                //create a recognizer
+                let pan = NSPanGestureRecognizer()
+                control.addGestureRecognizer(pan)
+                
+                //observable
+                let panEvent = pan.rx_event.shareReplay(1)
+                
+                //panning
+                if let index = type.indexOf(.Panning(.zero)) {
+                    //min offset
+                    let minOffset: CGPoint
+                    switch type[index] {
+                    case (.Panning(let point)): minOffset = point
+                    default: minOffset = .zero
+                    }
+                    
+                    //observe panning
+                    gestures.append(
+                        panEvent.map {[weak self] _ in RxGestureTypeOption.Panning(pan.translationInView(self?.superview))}
+                            .filter { panning in
+                                if pan.state != .Changed { return false }
+                                if minOffset == .zero { return true }
+                                
+                                switch panning {
+                                case (.Panning(let offset)):
+                                    return offset.x >= minOffset.x || offset.y >= minOffset.y
+                                default: return false
+                                }
+                            }
+                            .bindNext(observer.onNext)
+                    )
+                }
+                
+                //did pan
+                if let index = type.indexOf(.DidPan(.zero)) {
+                    //min offset
+                    let minOffset: CGPoint
+                    switch type[index] {
+                    case (.DidPan(let point)): minOffset = point
+                    default: minOffset = .zero
+                    }
+                    
+                    gestures.append(
+                        panEvent.map {[weak self] _ in RxGestureTypeOption.DidPan(pan.translationInView(self?.superview))}
+                            .filter { didPan in
+                                if pan.state != .Ended { return false }
+                                if minOffset == .zero { return true }
+                                
+                                switch didPan {
+                                case (.DidPan(let offset)):
+                                    return offset.x >= minOffset.x || offset.y >= minOffset.y
+                                default: return false
+                                }
+                            }
+                            .bindNext(observer.onNext)
+                    )
+                }
             }
             
             //dispose gestures

--- a/Pod/Classes/RxGesture.swift
+++ b/Pod/Classes/RxGesture.swift
@@ -21,41 +21,49 @@
 import RxSwift
 import RxCocoa
 
-/// An OptionSetType to provide a list of valid gestures
-public struct RxGestureTypeOptions : OptionSetType, Hashable {
+/// An enumeration to provide a list of valid gestures
+public enum RxGestureTypeOption: Equatable {
     
-    private let raw: UInt
-    
-    public init(rawValue: UInt) {
-        raw = rawValue
-    }
-    public var rawValue: UInt {
-        return raw
-    }
-    
-    public var hashValue: Int { return Int(rawValue) }
-
-    public static var None = RxGestureTypeOptions(rawValue: 0)
-
     //: iOS gestures
-    public static var Tap  = RxGestureTypeOptions(rawValue: 1 << 0)
-    public static var SwipeLeft  = RxGestureTypeOptions(rawValue: 1 << 1)
-    public static var SwipeRight = RxGestureTypeOptions(rawValue: 1 << 2)
-    public static var SwipeUp    = RxGestureTypeOptions(rawValue: 1 << 3)
-    public static var SwipeDown  = RxGestureTypeOptions(rawValue: 1 << 4)
+    case Tap
+    case SwipeLeft, SwipeRight, SwipeUp, SwipeDown
+    case LongPress
     
-    public static var LongPress  = RxGestureTypeOptions(rawValue: 1 << 5)
+    //: Shared gestures
+    #if os(iOS)
+    case Panning(CGPoint), DidPan(CGPoint)
+    #elseif os(OSX)
+    case Panning(NSPoint), DidPan(NSPoint)
+    #endif
     
     //: OSX gestures
-    public static var Click  = RxGestureTypeOptions(rawValue: 1 << 10)
-    public static var RightClick  = RxGestureTypeOptions(rawValue: 1 << 11)
-
-    //: all gestures
-    public static func all() -> RxGestureTypeOptions {
+    case Click, RightClick
+    
+    public static func all() -> [RxGestureTypeOption] {
         return [
-            /* iOS */ .Tap, .SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown, .LongPress,
+            /* iOS */ .Tap, .SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown, .LongPress, .Panning(.zero), .DidPan(.zero),
             /* OSX */ .Click, .RightClick
         ]
     }
-    
+}
+
+public func ==(lhs: RxGestureTypeOption, rhs: RxGestureTypeOption) -> Bool {
+    switch (lhs, rhs) {
+
+    case (.Tap, .Tap): fallthrough
+    case (.SwipeLeft, .SwipeLeft): fallthrough
+    case (.SwipeRight, .SwipeRight): fallthrough
+    case (.SwipeUp, .SwipeUp): fallthrough
+    case (.SwipeDown, .SwipeDown): fallthrough
+    case (.LongPress, .LongPress): fallthrough
+    case (.Panning, .Panning): fallthrough
+    case (.DidPan, .DidPan): fallthrough
+        
+    case (.Click, .Click): fallthrough
+    case (.RightClick, .RightClick):
+        
+    return true
+        
+    default: return false
+    }
 }

--- a/Pod/Classes/iOS/UIView+RxGesture.swift
+++ b/Pod/Classes/iOS/UIView+RxGesture.swift
@@ -23,18 +23,26 @@ import RxCocoa
 
 extension UIView {
     
+    /// Shortcut to `rx_gesture` for when you need to subscribe to a single gesture
+    ///
+    /// - parameter type: RxGestureTypeOption value, e.g. `.Click` or `.Tap`
+    /// - returns: `ControlEvent<RxGestureTypeOption>` that emits any type one of the desired gestures is performed on the view
+    public func rx_gesture(type: RxGestureTypeOption) -> ControlEvent<RxGestureTypeOption> {
+        return rx_gesture([type])
+    }
+    
     /// Reactive wrapper for view gestures. You can observe a single gesture or multiple gestures
     /// (e.g. swipe left and right); the value the Observable emits is the type of the concrete gesture
     /// out of the list you are observing.
     ///
     /// rx_gesture can't error, shares side effects and is subscribed/observed on main scheduler
     /// - parameter type: list of types you want to observe like `[.Tap]` or `[.SwipeLeft, .SwipeRight]`
-    /// - returns: `ControlEvent<RxGestureTypeOptions>` that emits any type one of the desired gestures is performed on the view
+    /// - returns: `ControlEvent<RxGestureTypeOption>` that emits any type one of the desired gestures is performed on the view
     /// - seealso: `RxCocoa` adds `rx_tap` to `NSButton/UIButton` and is sufficient if you only need to subscribe
     ///   on taps on buttons. `RxGesture` on the other hand enables `userInteractionEnabled` and handles gestures on any view
 
-    public func rx_gesture(type: RxGestureTypeOptions) -> ControlEvent<RxGestureTypeOptions> {
-        let source: Observable<RxGestureTypeOptions> = Observable.create { [weak self] observer in
+    public func rx_gesture(type: [RxGestureTypeOption]) -> ControlEvent<RxGestureTypeOption> {
+        let source: Observable<RxGestureTypeOption> = Observable.create { [weak self] observer in
             MainScheduler.ensureExecutingOnScheduler()
             
             guard let control = self where !type.isEmpty else {
@@ -51,13 +59,13 @@ extension UIView {
                 let tap = UITapGestureRecognizer()
                 control.addGestureRecognizer(tap)
                 gestures.append(
-                    tap.rx_event.map {_ in RxGestureTypeOptions.Tap}
+                    tap.rx_event.map {_ in RxGestureTypeOption.Tap}
                         .bindNext(observer.onNext)
                 )
             }
             
             //swipes
-            for direction in Array<RxGestureTypeOptions>([.SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown]) {
+            for direction in Array<RxGestureTypeOption>([.SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown]) {
                 if type.contains(direction) {
                     if let swipeDirection = control.directionForGestureType(direction) {
                         let swipe = UISwipeGestureRecognizer()
@@ -76,11 +84,73 @@ extension UIView {
                 let press = UILongPressGestureRecognizer()
                 control.addGestureRecognizer(press)
                 gestures.append(
-                    press.rx_event.map {_ in RxGestureTypeOptions.LongPress}
+                    press.rx_event.map {_ in RxGestureTypeOption.LongPress}
                         .bindNext(observer.onNext)
                 )
             }
             
+            //panning
+            if type.contains(.Panning(.zero)) || type.contains(.DidPan(.zero)) {
+                
+                //create a recognizer
+                let pan = UIPanGestureRecognizer()
+                control.addGestureRecognizer(pan)
+                
+                //observable
+                let panEvent = pan.rx_event.shareReplay(1)
+                
+                //panning
+                if let index = type.indexOf(.Panning(.zero)) {
+                    //min offset
+                    let minOffset: CGPoint
+                    switch type[index] {
+                    case (.Panning(let point)): minOffset = point
+                    default: minOffset = .zero
+                    }
+
+                    //observe panning
+                    gestures.append(
+                        panEvent.map {[weak self] _ in RxGestureTypeOption.Panning(pan.translationInView(self?.superview))}
+                            .filter { panning in
+                                if pan.state != .Changed { return false }
+                                if minOffset == .zero { return true }
+                                
+                                switch panning {
+                                case (.Panning(let offset)):
+                                    return offset.x >= minOffset.x || offset.y >= minOffset.y
+                                default: return false
+                                }
+                            }
+                            .bindNext(observer.onNext)
+                    )
+                }
+                
+                //did pan
+                if let index = type.indexOf(.DidPan(.zero)) {
+                    //min offset
+                    let minOffset: CGPoint
+                    switch type[index] {
+                    case (.DidPan(let point)): minOffset = point
+                    default: minOffset = .zero
+                    }
+                    
+                    gestures.append(
+                        panEvent.map {[weak self] _ in RxGestureTypeOption.DidPan(pan.translationInView(self?.superview))}
+                            .filter { didPan in
+                                if pan.state != .Ended { return false }
+                                if minOffset == .zero { return true }
+                                
+                                switch didPan {
+                                case (.DidPan(let offset)):
+                                    return offset.x >= minOffset.x || offset.y >= minOffset.y
+                                default: return false
+                                }
+                            }
+                            .bindNext(observer.onNext)
+                    )
+                }
+            }
+
             //dispose gestures
             return AnonymousDisposable {
                 for gesture in gestures {
@@ -92,7 +162,7 @@ extension UIView {
         return ControlEvent(events: source)
     }
     
-    private func directionForGestureType(type: RxGestureTypeOptions) -> UISwipeGestureRecognizerDirection? {
+    private func directionForGestureType(type: RxGestureTypeOption) -> UISwipeGestureRecognizerDirection? {
         if type == .SwipeLeft  { return .Left  }
         if type == .SwipeRight { return .Right }
         if type == .SwipeUp    { return .Up    }

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ On __iOS__ RXGesture supports:
  - .Tap
  - .SwipeLeft, SwipeRight, SwipeUp, SwipeDown
  - .LongPress
+ - .Panning(CGPoint), .DidPan(CGPoint)
 
 On __OSX__ RXGesture supports:
 
  - .Click
  - .RightClick
+ - .Panning(NSPoint), .DidPan(NSPoint)
 
 If you are writing multi-platform code you can eventually write:
 
@@ -49,7 +51,27 @@ If you are writing multi-platform code you can eventually write:
 myView.rx_gesture([.Tap, .Click]).subscribeNext {...}
 ```
 
-To observe for the concrete gesture on each platform.
+to observe for the concrete gesture on each platform.
+
+## Continuous gestures
+
+Some recognizers fire a single event per gesture and don't provide any values. For example `.Tap` just lets you know a view has been tapped - that's all.
+
+Other recognizers provide details about the gesture (that also might be ongoing). For example the pan gesture will continuosly provide you with the offset from the initial point where the gesture started:
+
+```swift
+myView.rx_gesture(.Panning(.zero)).subscribeNext {[weak self] gesture in
+    switch gesture {
+    case (.Panning(let offset)):
+        print(offset)
+    default: break
+    }
+}.addDisposableTo(stepBag)
+```
+
+When you subscribe to the gesture you provide the minimum offset the user needs to pan before the recognizer fires. If you use `.zero` like above you don't require a minimum pan distance.
+
+In the subscription closure you can pattern match the offset value and use it as you wish (full example is included in the demo app).
 
 ## Requirements
 


### PR DESCRIPTION
my initial idea was to go with an option set type for the gesture type (misled by the animation options in UIKit) but using constants to identify the gesture types isn't really enough.

For gestures like pan or rotate the observer needs to also get the current translation or rotation so using constants isn't okay. 

This PR converts gesture types to an enum and adds support for pan as an example.

A recognizer that provides value can be used like this:

``` swift
myView.rx_gesture([.Panning(.zero)]).subscribeNext {[weak self] gesture in
    switch gesture {
    case (.Panning(let offset)):
        self?.myView.transform = CGAffineTransformMakeTranslation(offset.x, offset.y)
    default: break
    }
}.addDisposableTo(bag)

```
