### PR TITLE
Increased the RxCocoa dependency version.

### DIFF
--- a/RxGesture.podspec
+++ b/RxGesture.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |s|
   s.ios.source_files      = 'Pod/Classes/iOS/*.swift'
   s.osx.source_files      = 'Pod/Classes/OSX/*.swift'
   
-  s.dependency 'RxCocoa', '~> 2.3.1'
+  s.dependency 'RxCocoa', '~> 2.5'
   
 end


### PR DESCRIPTION
Since RxSwift and RxCocoa were updated to 2.5, it's reasonable to update their version here to allow most recent RxSwift version usage in projects that also rely on RxGesture.
