### PR TITLE
Target taps

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -189,6 +189,8 @@
 		6A0028F41D3A66070062328C /* TapConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0028F11D3A65960062328C /* TapConfig.swift */; };
 		6A2E2C219DFF6D32C16239EE310606E8 /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236983DA69E6A12F58775605239117DE /* RefCountDisposable.swift */; };
 		6AAF23825904D6DFC9229E6C7BD8CA4C /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09F8FD785663489A532E8A69164E9C /* SynchronizedUnsubscribeType.swift */; };
+		6ABFAB771D3BA99D00CEBF96 /* LongPressConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABFAB761D3BA99D00CEBF96 /* LongPressConfig.swift */; };
+		6ABFAB781D3BA99D00CEBF96 /* LongPressConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABFAB761D3BA99D00CEBF96 /* LongPressConfig.swift */; };
 		6ACDA50CF7E4AA489A05B943886D1329 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C544817D76E71D828DB3AE0EE5DFA3 /* InfiniteSequence.swift */; };
 		6B702CBA3187CA6D991CBE76351837FD /* Observable+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806CC77B1040592A24B4F57B756C9AA /* Observable+Time.swift */; };
 		6B81B26818BFF79D9DE0909B20812BE6 /* Pods-RxGesture_iOS_Demo-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FBC2B3604E156C2B39FB243BDBF5FBDC /* Pods-RxGesture_iOS_Demo-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -653,6 +655,7 @@
 		680753ED29B2B36844E7BF1D3EC725DE /* VirtualTimeConverterType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VirtualTimeConverterType.swift; path = RxSwift/Schedulers/VirtualTimeConverterType.swift; sourceTree = "<group>"; };
 		6A0028F11D3A65960062328C /* TapConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TapConfig.swift; sourceTree = "<group>"; };
 		6A7E2B288AEF9F04DA4D3DAF5B40E7F1 /* Repeat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Repeat.swift; path = RxSwift/Observables/Implementations/Repeat.swift; sourceTree = "<group>"; };
+		6ABFAB761D3BA99D00CEBF96 /* LongPressConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressConfig.swift; sourceTree = "<group>"; };
 		6B52DF800B19E074DBC494C3F9A24063 /* BinaryDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BinaryDisposable.swift; path = RxSwift/Disposables/BinaryDisposable.swift; sourceTree = "<group>"; };
 		6CD4E7DF61DAAA84A22AB05AD877367C /* UITextView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UITextView+Rx.swift"; path = "RxCocoa/iOS/UITextView+Rx.swift"; sourceTree = "<group>"; };
 		6E0C7DD780E181D0F5EB28D77EDB199C /* SerialDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SerialDisposable.swift; path = RxSwift/Disposables/SerialDisposable.swift; sourceTree = "<group>"; };
@@ -1277,6 +1280,7 @@
 			children = (
 				383E8395E05602750FB92C87A2FDEB92 /* PanConfig.swift */,
 				6A0028F11D3A65960062328C /* TapConfig.swift */,
+				6ABFAB761D3BA99D00CEBF96 /* LongPressConfig.swift */,
 				B938000B6A988DBB740EE2ED9F411571 /* RotateConfig.swift */,
 				B9D561015C9DD423C4695CE8F7CAE062 /* RxGesture.swift */,
 				8FC936CA127BE8A8C9DE8621E29025C9 /* iOS */,
@@ -1686,6 +1690,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A0F6D25550D0AB1122728E0E202E9B2F /* NSGestureRecognizer+Rx.swift in Sources */,
+				6ABFAB781D3BA99D00CEBF96 /* LongPressConfig.swift in Sources */,
 				A8D37F4EA054BE484E3BB6DC1A471493 /* NSView+RxGesture.swift in Sources */,
 				DCA27732462FA9070AE710D9A361ADA0 /* PanConfig.swift in Sources */,
 				0CE1F2ABB8602030A1F03084D04D59C5 /* Pods-RxGesture_OSX_Demo-RxGesture-dummy.m in Sources */,
@@ -1801,6 +1806,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A01F5D8032F07A5A0D80DCEA17D7282 /* PanConfig.swift in Sources */,
+				6ABFAB771D3BA99D00CEBF96 /* LongPressConfig.swift in Sources */,
 				6A0028F31D3A66050062328C /* TapConfig.swift in Sources */,
 				14E592CECFBE338044522B24E1481FE6 /* Pods-RxGesture_iOS_Demo-RxGesture-dummy.m in Sources */,
 				7783C8B43B0F83A3E122DF1748EC8CAB /* RotateConfig.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,10673 +1,2792 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>0047D7C07D4E7168D66A6B195B20AF58</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ConcurrentDispatchQueueScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>00F8A441477F0B251EE61CF7A98BED9B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D12DB9FC05ECEBD079763E18E22438A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>010C64612B6F3C569DD06BF294943208</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20587B5EBF4383E9A1A39FA525D0213B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>01803CDE548981116E7A943E1E109A39</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C87E53818AF138ACF5D61B3D7D6E5274</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>018B5C8CFEFFB40F36662FA6FE88DAF1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSButton+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/OSX/NSButton+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>01E61E8DC081EA6C0009BBD7057D29C1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2488AC35E99BBB5538B1BD95F7655E94</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>02736A0824ED21A5F170A055AAC18B5E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Do.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Do.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0278F3FA193A3C83B14B2E3F9ED87E2F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ItemEvents.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Events/ItemEvents.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>02A10A251161E99CA06BFBA191386FB4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RetryWhen.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/RetryWhen.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0305F269FD99A7E9B15020CDE7EC04AC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2576CF8363182027D6275CCCF79BFF09</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>032DD707905DA8D3C57277EF878F3240</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Take.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Take.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>036645378416B45CDB8CE10B07BE2213</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SerialDispatchQueueScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/SerialDispatchQueueScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>04B59445A37377F5D0DF638B75676F9D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D2AD1791E2917EF6FCE255F4894FA8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0522CD8F0D5EA4DD356A6C34B68879AB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>WithLatestFrom.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/WithLatestFrom.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>056D9D725EE24B24614AF91C4E832CE6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C4122641759BCB149F3FCADD5C3268F7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05974E627F79103F55BF0441A036DC2B</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>66A0A91B504135AF2AECC09049FA49A3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05B217FDEBD05EAF43320C9D44E5D002</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2F709B0640631738B641635327262486</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05BD51B2599DFF8C9D77DF9CCAB2F8CD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F2C2A9E19936B336BC0C7AE82D875826</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05C4DDCFD41B0362192795C66D54E2D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C63811859DE646A04ED30107BC30950A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>06063B1BB0E18FA159CEC26B2275178D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SingleAssignmentDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/SingleAssignmentDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>065D3BEF76FFE3B3DF7B72302D5D7DB0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C64491ABA744A4BD99C4CB1D733B5DA3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>068C90A9229762E4F318F6CD34B2ECF5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>06E0F99179E5CCB68C4721ECC9703E40</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTextViewDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>06E8FE7D88F5AF65F3E6D57C39B12F30</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AnonymousInvocable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/Internal/AnonymousInvocable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>07537B3412788F76A1CADAE162264580</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9A2B0DA384E6A125B6430754BD9E8241</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>077B2088D0B86F82BDEBA1EBFAE9669A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BFFB4F5995EE9165EFF01A1B67E31329</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>086E33B335E329AF6B3E4840A5067F05</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift</string>
-			<key>target</key>
-			<string>9B27914C2D65E7BCA3CAB1D2365E645D</string>
-			<key>targetProxy</key>
-			<string>CA7750E5ABEF5F2B68D50415B80A5EC9</string>
-		</dict>
-		<key>08D2BF0199EBBCEC535A63481EEA6E5E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3C99CE41C2C08F13D0EFB93F9F1AA297</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0905B95004BC92DB93247A62B00B3165</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Map.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Map.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>09B3B057734A3D96C3EFDEA6F6098411</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C7A741BE56BF66F4F2242CF3B34F1E6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>09DE898823F74CB06BE5792F0CC7D1B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0905B95004BC92DB93247A62B00B3165</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0AA76BFB01DDC6C4DC5206BAAFB02AB5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4CDA9865788B870D2E0C9631A55AD2FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0AC1F877E92090E34F5CE2FB79F4629D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>CLLocationManager+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CLLocationManager+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0B4B7D83E73B0AA1350996A9C1A69BE3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3E46C8CA6BBF11ADED61F1E96D33D598</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0BBB68551EADF40B6394870505DC681B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>631A1DD20311EE54BC795DF915327298</string>
-				<string>13DAA72FFC4FEC8282FF159AF25E6C3C</string>
-				<string>24D7C3299CAA95F0C27AEB129A52E6F1</string>
-				<string>E2EB128A6BB718BA85611E62366C103B</string>
-				<string>CB761ED25DD8E01E6FE70D51365524DB</string>
-				<string>4F30C3F0E32A967675B65D48BEAB63A4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0BDB8D850932A64821E98B8CF500069E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0C47F7A3A711DEF2852287E958912400</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEDB7B436E22D693CB5360DB88CE7450</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0C4F3EAA99C096AD1085CA2A48A5DC85</key>
-		<dict>
-			<key>fileRef</key>
-			<string>880EC46B2EA4171F124091B6A8EEC9BE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0C9289AF05996A8D7D12EAAF8869DBA2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SubscriptionDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/SubscriptionDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0CBCDC693500CA15D126A035DB4D4367</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06E0F99179E5CCB68C4721ECC9703E40</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0CC3868667FB42D9AE0F41894DFF9817</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80464EA0B50C6A06A9C5061AA0E72B6E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0CE1F2ABB8602030A1F03084D04D59C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6125CFE9D1577552DB75431F0817A868</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0CFA33E64D14743BE85F0223890703FF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>036645378416B45CDB8CE10B07BE2213</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0E6188767C3FAF3698E2230366164E66</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2E09F8FD785663489A532E8A69164E9C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0ECA27BEBCA1AA178470104FBD0E29D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9EBAC0789FA5CD3B9A97859B6633DD22</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0F0D9C24C0E44E57008ED781A6A9540A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CCFDBBFF08F74F9511DF21F873EABE86</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0F6A376FDBDBE0F5EC0A5DFCA1E41EEC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C3923EA7357FC6223BC856AAE0F07580</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0FED2EC4C912C80F8F0A4FE9E545CB4E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SubjectType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Subjects/SubjectType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>100E0FBCFBCB8BE4FEBE0CC293730203</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7968685A24D6C361EE9E76D7D17C454B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>102827C3A99E45D1C6FDE5A5DBC0E68E</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>D7D2E8A3E11B6A93694AEE6F34218DD3</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift</string>
-		</dict>
-		<key>1035B16F5AEAD95D6CE0D08BF42A068F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>810CDFDD1F29B38A57A777A0E34E51F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>106A4BA5EE50593CF0EF869952FF8DCB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0FED2EC4C912C80F8F0A4FE9E545CB4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>10EAC6560D0E865FC286D0B2CEB21F8D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ConnectableObservable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ConnectableObservable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>12057F126FEE11DB7394DA87B1E8ED18</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8F0081C0EB913B4A12C9BA7F9E2C44CA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>12B7233B7F267BF399EEED6714BCE42D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>13240DAE3074045875C9BF40FA6C2D8C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>714C5305FFAFC2F0793D969801E49179</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>13415C7329C8E3CA1EF501EB6450CF3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>867FB6D9CD5ADD06727AA1E89197078D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>13477CD7CE62DA553A65F4E8588AC29D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>42922C460C6B4921C335F9A0AB78966B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1371EDFFD119B102C16B66F5769F97F0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Single.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Single.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>13DAA72FFC4FEC8282FF159AF25E6C3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1F4249BCB52EA315CF45C8AF750220C3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>14E592CECFBE338044522B24E1481FE6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>12B7233B7F267BF399EEED6714BCE42D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>14F0CB6A70A3D96F1C4BE2E5CCF9C2C4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>19E010F7B88BB02E629463A73BA403E1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>14F184D4578891EF5AF48A72242696D6</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>A653AC721AB76BD247BD21ACB54FC4E1</string>
-				<string>303BA170CFDE25D980D0B4DA54BDAB58</string>
-				<string>EB2A84A5948EBF2DF07E8C6C1535F69C</string>
-				<string>20C06CF74646A61B0C5EFF0F626C346F</string>
-				<string>752964FCFB788000B79D21627D4D737E</string>
-				<string>C2C7F0554D20A58F6D5E3657640E6745</string>
-				<string>26FDC717A2FA97E2A878CCE2092994BC</string>
-				<string>0AA76BFB01DDC6C4DC5206BAAFB02AB5</string>
-				<string>E04FB4107DD3A5DCF1062A8E82ACA4F3</string>
-				<string>CADA73E1D18C4B1507FA15CE4A973324</string>
-				<string>57E883ABEAA37C1D5A61A17EDF8C5CF6</string>
-				<string>F06E6FB5C72FA43030789513F4821926</string>
-				<string>00F8A441477F0B251EE61CF7A98BED9B</string>
-				<string>6C8881718CC15265D09C41CBB10B7E9E</string>
-				<string>4BBFDC66B5D6EDBA302DFCCD0A31BFD5</string>
-				<string>847D340E4481EB953B56E987A8863B62</string>
-				<string>536AE1D5281359DEF6F7890B09F1B40E</string>
-				<string>D85E2176535BD6BEB9DC135A7F8B1C18</string>
-				<string>91721397EC011682D479904C93C12753</string>
-				<string>2A61A0A93B128DEAA575ED886869D432</string>
-				<string>57A44A6F3687891BCF5CB0CDB1B1B7B7</string>
-				<string>2A1CD5FC5B38CC1653414E3AAA7A02B3</string>
-				<string>9DDCA6731F75967C99C394CD687BA328</string>
-				<string>FE6A06583DCAD5929380A73780693C1D</string>
-				<string>2D92995D37170EFA5808AEF0155AB522</string>
-				<string>CBA8DBF45CDA4CFC978E23AB26A807E8</string>
-				<string>1E5FB7BCA876FA81FC36980DBF774826</string>
-				<string>4F2D991B08E329A0337FB73CACB68194</string>
-				<string>732C1BA4FEAEBF02986DD3EE64224F80</string>
-				<string>FBE1FA148B8A7875D8A705D0C9804762</string>
-				<string>D92B1754DDCAEF92566DAC3592014D73</string>
-				<string>2DDA95E846507AC77F703CA51635C9B7</string>
-				<string>FA9E64EF1F16C9A75321D321AB87C4A4</string>
-				<string>0B4B7D83E73B0AA1350996A9C1A69BE3</string>
-				<string>3B60F86E57C6E0B5EB1C16329497CA38</string>
-				<string>2FE889C233DB3D6EE9B795A6B49DEBF2</string>
-				<string>CF029F863E85E7C03591D4210989B647</string>
-				<string>4E118E5BBB86F4E3D5BE4404D82BE6D0</string>
-				<string>72C524E7B71E56E69737978A30762BD0</string>
-				<string>455E80A5EA99580469518024869EA1AA</string>
-				<string>B77B250A5C4091D9437711ACFFE1A60B</string>
-				<string>E5AAEEC20D987248D63ADAEC556054C8</string>
-				<string>A1558AC0EC6057A3B2E5C0A902FC1623</string>
-				<string>4243ABB4D6D5A1F0E3F004DD880FCC0B</string>
-				<string>615B0141A00A2139932548F59332833A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1514F07E372FBDC4AC1D948329D062B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>58ECEFE2F4CC184ABFE4A7BD4F63F568</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>153315CB7CE0328B96834073C4C53691</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8822B80A6A868B58E68512A9C1288FC8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1541EFF54CE15FA4247A89DFB63268D8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>String+Rx.swift</string>
-			<key>path</key>
-			<string>RxSwift/Extensions/String+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15A306E295D2367B200DE30C17839B09</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6B81B26818BFF79D9DE0909B20812BE6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>15B5E4C3EFE2725A54E98104C2781351</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D72318DBF092553E249C7DEA4BD4BEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15F4962BEBC4BA7715C5AEABC392D477</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FA6793E8440943D0A3CE5EC20DCC7FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>16B4F8DCF4CBA99637141D6CCD6AD93D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1769EE025DD222C127D3D32B83C90BC0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSImageView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/OSX/NSImageView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>17744F33B9814C0F99CD9610B6F63A3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B746BEBFCD9CFA793E10E15D5E7B47D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1799597E775C55C9969167456E64659A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>5F73DCC6D3F37BDB0EE4D0E020E4901D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxCocoa</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>17F984370AC1D8AD4B483F2E27E48830</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-frameworks.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>18570A91E717C6ACB651EF74D1504147</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE4BF2809DFC533229426FC2B1D4AF91</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1897D796678C177CDE2943A913694DA1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>71AFAD963301C46BC7BC87E5B3D2F396</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>18BB6406DBA51C04A9070E7DAE7CEA32</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06E8FE7D88F5AF65F3E6D57C39B12F30</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>18F6CBEA55853D5400671FFC872FEB8D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FC3A97DF6DC20E8FA7115AF427A1FDA3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>195A0BC9DB44EB9697A3A61170725E9E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3EE67AD4EF9BB7255F12A8E1ACF59F43</string>
-				<string>9786556AA0483D04DD189DA66A8BB80C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>19A8502B4392E2C35D5ECF8145E781DC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Merge.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Merge.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>19E010F7B88BB02E629463A73BA403E1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Disposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1A0E104B9153F15585DEC6956D497ACD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SynchronizedSubscribeType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/SynchronizedSubscribeType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1A2DA45028046C38FA03EA5A688E9AB4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxSearchBarDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1A6B5613B12EDBA017A9204D949A4D2A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>937967AE1F14874EF338B1B8F57AA23B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1B16C8535DFF1BF401E7610C26D5A1D9</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>82A721AFC5D1B757D919FEC84F9FEF74</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxGesture</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>1B3B751B0C5F626CB6E8FCE543FF5CF5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NopDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/NopDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1B4A8D83F816BC448322BC0057DAA019</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A4F910A4EF4840DF1A5FA245812BEB1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1C2DB5C4B575F0B74C596E23A59C934A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9D561015C9DD423C4695CE8F7CAE062</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1DEA721BCEC873F79234C5E63F2548B8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A12623F1AB0752800B1DB10DF0417CF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1E30F06ECF68CB0C48EA50C7EE7B2433</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxCollectionViewDataSourceProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1E5FB7BCA876FA81FC36980DBF774826</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1769EE025DD222C127D3D32B83C90BC0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1F19AA9E3785650C8EB42205C1EC4C29</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RxCocoa.framework</string>
-			<key>path</key>
-			<string>RxCocoa.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>1F4249BCB52EA315CF45C8AF750220C3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>_RXDelegateProxy.h</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RXDelegateProxy.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1F76BDB26F35646A511521BFC163D808</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E7731A4628E596D95ACD0AFE6EEBBA43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1F8E6558BAC2C93227F65E3870B19264</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>AFE010FEC036F74911E6F9609402C03F</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxCocoa</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>20587B5EBF4383E9A1A39FA525D0213B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Empty.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Empty.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205B1218645F50D5705293C3858B0490</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F8CC9CB96DA7D4844F559C8C80088CD4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>20618F75B2A8404B53E0916FE475229B</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>97E089F34EA8E281F450990124ADE867</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo/Pods-RxGesture_iOS_Demo.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_RxGesture_iOS_Demo</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>20C06CF74646A61B0C5EFF0F626C346F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7CD8DFA3BDA378BDC5FF885379349130</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>223D2D9A89527A00F2C9592CF7FE7DFB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SkipWhile.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/SkipWhile.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>226B5AC3BB6D95D9409C54D83CFBBDD4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>BooleanDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/BooleanDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>23150967BB721DD3EDF525D42D23C69F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06063B1BB0E18FA159CEC26B2275178D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>236983DA69E6A12F58775605239117DE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RefCountDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/RefCountDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2372E8B1408EA57F7E143EB87A85881F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A23025D7CBEA011BDDB9A5ECF666C1E8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>23978FC6352310883C0A2876EB707671</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1A2DA45028046C38FA03EA5A688E9AB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>23B972FE2CA4CA82B850AB93E1490E98</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>16B4F8DCF4CBA99637141D6CCD6AD93D</string>
-				<string>7CDC591FE27EDF0166C359C990E9F4FA</string>
-				<string>6487EE29EEB4C56EED2333CF8AA5A55D</string>
-				<string>4B860A00382AC06FCFA0D8436A433574</string>
-				<string>8822B80A6A868B58E68512A9C1288FC8</string>
-				<string>17F984370AC1D8AD4B483F2E27E48830</string>
-				<string>A9446ADAA8A85A0CD4223AB8788DC5B6</string>
-				<string>8614B5BCCE597A517451A65FDCCF091B</string>
-				<string>969EF9A054D7A4FF9D52EC47F03E29BB</string>
-				<string>0BDB8D850932A64821E98B8CF500069E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-RxGesture_OSX_Demo</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>23D44BE2351ABF5A8F0A758F9E97591D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D9CDE42D609590B6AA8AAD038BF20E21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>23E941CEBFF4F79C8A915B8ED8FD1827</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5C5A1CF70E522B6D4494C37B1C06F6D3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>242CF41A195F0BFA5D26BA5901A077EA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AE2DE95184E55408F0BFC4D170AF4C04</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>245AC5100739C5A8E44FBFE74CCCCC12</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DispatchQueueSchedulerQOS.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/DispatchQueueSchedulerQOS.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2488AC35E99BBB5538B1BD95F7655E94</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Bind.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observable+Bind.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>24D7C3299CAA95F0C27AEB129A52E6F1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EB39ED08E4C74181954C6B42D69F7FB7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>24D88A7B7FE5BB4A952752420717A25A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2C6AB6AEB9265AFCBF6B63FE10D75B45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2548DC0992B55BE1E01A3957E8DD6D31</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6A7E2B288AEF9F04DA4D3DAF5B40E7F1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2576CF8363182027D6275CCCF79BFF09</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIProgressView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIProgressView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C05A083F477603B7EA669638EC0016</key>
-		<dict>
-			<key>fileRef</key>
-			<string>666CEAE2C63819EF5FAC680D6243A456</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>260BDDD7A70035E73256485415DEEAFF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D859CDF029BE59A16868AB0E614D41BB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>268CE435B9F2129DDA96FB23522870E4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A47B3D1B773D68299EDABB9A4D54E96</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>269992A3BB1AD297195CB4C3A382DDDA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DF3C7C58743CE4D5B3CC5515C5803942</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>26AAE4981F2B2A0B345D49C6FFF3F191</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>_RX.m</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RX.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>26F86A42574378E3C19BB20A1D4F6EE1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Debug.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Debug.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>26FDC717A2FA97E2A878CCE2092994BC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>46DD1AB167A06B315005919A9BD6E8B4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>270525BB31443A4DDFBC264C35F83AA2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D368C07F4793B141BBE46A5B8453B177</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2707BE20B947454620D28D8E8DC421AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0C9289AF05996A8D7D12EAAF8869DBA2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>27319C465E633116B267CA247084A624</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7C0C813650AFCAACE69C0BBAF5A9D251</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>275E8986FB7ADB3A095558F0BF433833</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C25308CFE7CECE3CF7E9AC0EBBD33AF9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>275FF153A051A414EE420FC3E9FB1027</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D91B8FB88CC735C3CC651A2DDAA219E5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>283198B3A1BC9C9C64AF8776DF9D8602</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Driver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/Driver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>28DB94F701EECB69825350684A061A4F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>548BFBF4A1720DBCC0CDA20A3FC5F98E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2A1CD5FC5B38CC1653414E3AAA7A02B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3A8C262F7B62C28B263F49AACFDFAB2D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2A61A0A93B128DEAA575ED886869D432</key>
-		<dict>
-			<key>fileRef</key>
-			<string>54133C9D54D6BD5ED81DAE23B47861CA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2A940E69BC5371EEA2C7CCEACA25AB6C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4367F29A7CAE5D22120821D3736AB6BB</string>
-				<string>1B16C8535DFF1BF401E7610C26D5A1D9</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2AC4CA10BF5CA4BC515B472AEDE54445</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CA440FABEECC06934002C5B7DFFD96C3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2AD0AB82C8DCDE62D31342BBA1A5AB70</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>37B0B8B080F1E6B923BEFBBF2DC5B11C</string>
-				<string>920C57CA223DED99EA2B9BF7416E8664</string>
-				<string>CAC81FC6ADF84CBF9D24DF18F08820B7</string>
-				<string>06E8FE7D88F5AF65F3E6D57C39B12F30</string>
-				<string>DFDC7869C929289A9CD3A92B63C692D1</string>
-				<string>BFFB4F5995EE9165EFF01A1B67E31329</string>
-				<string>F52B7AE23C229717D736C40F90B8D574</string>
-				<string>42922C460C6B4921C335F9A0AB78966B</string>
-				<string>53E085BA27253B4EFEDD426526E4A96A</string>
-				<string>CA440FABEECC06934002C5B7DFFD96C3</string>
-				<string>6B52DF800B19E074DBC494C3F9A24063</string>
-				<string>226B5AC3BB6D95D9409C54D83CFBBDD4</string>
-				<string>9EBAC0789FA5CD3B9A97859B6633DD22</string>
-				<string>3871A7C8372F1322E306860D1430882B</string>
-				<string>C25308CFE7CECE3CF7E9AC0EBBD33AF9</string>
-				<string>8FB5D2484879C5E0D0AC211D9FC603D5</string>
-				<string>8F0081C0EB913B4A12C9BA7F9E2C44CA</string>
-				<string>F90193FA637C5E3C76DCF1888950DB2C</string>
-				<string>79EEA13950D3C7E26EA2C570F80B66C2</string>
-				<string>D9F0A2FEE585A9018680D5769208A755</string>
-				<string>0047D7C07D4E7168D66A6B195B20AF58</string>
-				<string>60F618BDF7BC2AC6CC2A49F4069E5944</string>
-				<string>10EAC6560D0E865FC286D0B2CEB21F8D</string>
-				<string>4A2B40CC335CF4F90488701FB34D321D</string>
-				<string>2DE492C558DEBA31064661917BC71BE2</string>
-				<string>DA6D897F503A3460A4E195622BACB277</string>
-				<string>80464EA0B50C6A06A9C5061AA0E72B6E</string>
-				<string>449F0019DD1F3E76574EB8C06356C328</string>
-				<string>245AC5100739C5A8E44FBFE74CCCCC12</string>
-				<string>19E010F7B88BB02E629463A73BA403E1</string>
-				<string>FDA6B4837F238135EDBB1FD219AC21E8</string>
-				<string>52DE9731E7AB29C0A4F4994F544D31EC</string>
-				<string>41691D1578A4288F5D547260BF7422E4</string>
-				<string>02736A0824ED21A5F170A055AAC18B5E</string>
-				<string>5FC278E77933E0D1F364DBD2B0A24180</string>
-				<string>20587B5EBF4383E9A1A39FA525D0213B</string>
-				<string>C4122641759BCB149F3FCADD5C3268F7</string>
-				<string>C862CF3BD7290855D8AD7565CD8E2666</string>
-				<string>3923CF81B57F0AB60F4DE73C980321DD</string>
-				<string>E7731A4628E596D95ACD0AFE6EEBBA43</string>
-				<string>A16B90AA9D152514C8ADF7451C1E90A4</string>
-				<string>F60D78F33A072FBB5C97E5841B867C77</string>
-				<string>DF3C7C58743CE4D5B3CC5515C5803942</string>
-				<string>C3923EA7357FC6223BC856AAE0F07580</string>
-				<string>6FD15299911C10004D6C338D4883BEA6</string>
-				<string>E1C544817D76E71D828DB3AE0EE5DFA3</string>
-				<string>B0105A3A5AF33D1CF3973AD0CF4AEB9C</string>
-				<string>371997EFA02B3641F6F5DCA3462F231D</string>
-				<string>B746BEBFCD9CFA793E10E15D5E7B47D4</string>
-				<string>7C0C813650AFCAACE69C0BBAF5A9D251</string>
-				<string>32333103781E0D7296DE45160EFFCF8A</string>
-				<string>33A5CCFF7C755C16BD3B5DB4FFE1F88D</string>
-				<string>0905B95004BC92DB93247A62B00B3165</string>
-				<string>19A8502B4392E2C35D5ECF8145E781DC</string>
-				<string>C63811859DE646A04ED30107BC30950A</string>
-				<string>714C5305FFAFC2F0793D969801E49179</string>
-				<string>442E13A5AA3E5B956BF394857AB8456C</string>
-				<string>1B3B751B0C5F626CB6E8FCE543FF5CF5</string>
-				<string>DA208E4396D571B3FF2C758E089F3C95</string>
-				<string>B5B69664E4718AC7434121C115138625</string>
-				<string>7E897AFACD8C7C5E2A001D27DE0B4618</string>
-				<string>D91B8FB88CC735C3CC651A2DDAA219E5</string>
-				<string>7968685A24D6C361EE9E76D7D17C454B</string>
-				<string>26F86A42574378E3C19BB20A1D4F6EE1</string>
-				<string>ACDB236E3E70B35781D525D0318E5BB7</string>
-				<string>B94D6C7DD2DDCFDF47973632D61DB036</string>
-				<string>1371EDFFD119B102C16B66F5769F97F0</string>
-				<string>9DD6A6C23C63D4EB73064E6C68E20CD5</string>
-				<string>8806CC77B1040592A24B4F57B756C9AA</string>
-				<string>867FB6D9CD5ADD06727AA1E89197078D</string>
-				<string>D2AD1791E2917EF6FCE255F4894FA8AD</string>
-				<string>4B57D8DB71BDAB80D01EB772BB8B51EC</string>
-				<string>D9688474E44B841F6129B4FAFFB2C565</string>
-				<string>D368C07F4793B141BBE46A5B8453B177</string>
-				<string>8D3FD3990B8A1E9548CB62F43886EADA</string>
-				<string>70C8BBEADC28B99A09E31C0BC5FE57FD</string>
-				<string>F86FFCA66ED86F404880F6B796F87F05</string>
-				<string>DD670E6BA419147639CA62FC8C3CEDA5</string>
-				<string>5F569847A7107D9276E4725C50D0916D</string>
-				<string>65D1EB659125EA3969D59014B9F4E1A4</string>
-				<string>CA682272C2916EFCE819012AA8F6F4C6</string>
-				<string>3A847199C59581AE111ED00A7096043A</string>
-				<string>3E98F8FEECEC2DD9F966C9D3E8807071</string>
-				<string>A9BF5397CE64E09EB5C37D737FA40398</string>
-				<string>3426C8436E0E44F1E70A1F7BC6D4BF63</string>
-				<string>FB5C6A9BAE45FFA2C75DC00EC9F9430F</string>
-				<string>236983DA69E6A12F58775605239117DE</string>
-				<string>6A7E2B288AEF9F04DA4D3DAF5B40E7F1</string>
-				<string>2C6AB6AEB9265AFCBF6B63FE10D75B45</string>
-				<string>02A10A251161E99CA06BFBA191386FB4</string>
-				<string>CAAFF37D2CE77D76494B7F42ABF4792A</string>
-				<string>C64491ABA744A4BD99C4CB1D733B5DA3</string>
-				<string>A995AACF502C4037D6FBC4C6112ED3BB</string>
-				<string>CB32E46DA8057A3A622F29F4500772A2</string>
-				<string>FC3A97DF6DC20E8FA7115AF427A1FDA3</string>
-				<string>419FD89DFCF42A6ADFE86D2D84B0EA46</string>
-				<string>C7A741BE56BF66F4F2242CF3B34F1E6D</string>
-				<string>573193BEB3DE9B1053800EFB15956A04</string>
-				<string>B594A1B0AF0D78EE827EB80F48CFEDDA</string>
-				<string>666CEAE2C63819EF5FAC680D6243A456</string>
-				<string>036645378416B45CDB8CE10B07BE2213</string>
-				<string>6E0C7DD780E181D0F5EB28D77EDB199C</string>
-				<string>784DCD30FFABD70154CB39E13ADC428B</string>
-				<string>E145F810DEFF07BCE812538BFA651708</string>
-				<string>06063B1BB0E18FA159CEC26B2275178D</string>
-				<string>D94C88848C57B60ABE5E9867B1942078</string>
-				<string>7BCED313175C4FDCE4ABF2985910FD43</string>
-				<string>C87E53818AF138ACF5D61B3D7D6E5274</string>
-				<string>C3A0C86A2E540C585BD9EED8227FC082</string>
-				<string>223D2D9A89527A00F2C9592CF7FE7DFB</string>
-				<string>B8A2FE6EDBAF67DE1651CFA7C30C0FA9</string>
-				<string>AE2DE95184E55408F0BFC4D170AF4C04</string>
-				<string>1541EFF54CE15FA4247A89DFB63268D8</string>
-				<string>0FED2EC4C912C80F8F0A4FE9E545CB4E</string>
-				<string>A23025D7CBEA011BDDB9A5ECF666C1E8</string>
-				<string>0C9289AF05996A8D7D12EAAF8869DBA2</string>
-				<string>85B26A5D41DBB998BC91E988B0B68FFF</string>
-				<string>EDBB3142C058BFF8F0B79E20C43D86F8</string>
-				<string>3ADD86DB658ADA7B22F4A9E9D1DA25A8</string>
-				<string>1A0E104B9153F15585DEC6956D497ACD</string>
-				<string>2E09F8FD785663489A532E8A69164E9C</string>
-				<string>AC31759D90FFBB778349105CD32B82A0</string>
-				<string>032DD707905DA8D3C57277EF878F3240</string>
-				<string>C686CEFDB56AF5DFB18118006274FA02</string>
-				<string>B54EEB7F3D9B9D4D2E5708405A57F65E</string>
-				<string>D9CDE42D609590B6AA8AAD038BF20E21</string>
-				<string>880EC46B2EA4171F124091B6A8EEC9BE</string>
-				<string>66A938D2640AAB94C102006232D3177B</string>
-				<string>E4DCA1F1EC467C456DE2F6B57B5C35A6</string>
-				<string>A3B83162A671B863092C509640455BB1</string>
-				<string>E34A5CB470BDF4610D116B4C6E6310CC</string>
-				<string>8A47B3D1B773D68299EDABB9A4D54E96</string>
-				<string>680753ED29B2B36844E7BF1D3EC725DE</string>
-				<string>D0E9E99E1790D8207298D944DDA5D4A2</string>
-				<string>5FA6793E8440943D0A3CE5EC20DCC7FC</string>
-				<string>0522CD8F0D5EA4DD356A6C34B68879AB</string>
-				<string>C7E745319BCA81A3F171ED2C1DF23643</string>
-				<string>713CD0C782C89D147C113A835FA5BD81</string>
-				<string>9D04517DD6AD2781E4CB927E673828D5</string>
-				<string>771B9761981CCDDC31120956AFB6D6D5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RxSwift</string>
-			<key>path</key>
-			<string>RxSwift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2B0D27F069E8F0E701A6C9CDD3F57504</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F20316FCE33298DCDDE596E17F8ABF9B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2C6AB6AEB9265AFCBF6B63FE10D75B45</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ReplaySubject.swift</string>
-			<key>path</key>
-			<string>RxSwift/Subjects/ReplaySubject.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2C771E3DEEBCDCCD7642FFBC88F4B21A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7968685A24D6C361EE9E76D7D17C454B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2CDEF5835D5C10A026F090259385CC21</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UITextField+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UITextField+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2CE57331ED99C2D3E28CC5FA7F2E489E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7C0C813650AFCAACE69C0BBAF5A9D251</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2D0298A8428E79167215D2B8D70D16A5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObservableConvertibleType+Driver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/ObservableConvertibleType+Driver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2D670B044F667B3ABB1F4F604E72E380</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3DC2B0E80E48647EAF1B31B4333EE75D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>CD4013CD18B320C79647E2D4EA37E582</string>
-				<string>856BEF17CF7475929D62A60D15415559</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2D92995D37170EFA5808AEF0155AB522</key>
-		<dict>
-			<key>fileRef</key>
-			<string>018B5C8CFEFFB40F36662FA6FE88DAF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2DDA95E846507AC77F703CA51635C9B7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FDEB61CDD7978740C1A32E03C8A96C40</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2DDF89976DA0A48A2EEA28FFCD90E170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>713CD0C782C89D147C113A835FA5BD81</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2DE492C558DEBA31064661917BC71BE2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>CurrentThreadScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/CurrentThreadScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2DF76949F9A826C7D066D20516A6268E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2E09F8FD785663489A532E8A69164E9C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SynchronizedUnsubscribeType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/SynchronizedUnsubscribeType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2E0F6361F3899645D43F388A5C267D4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>223D2D9A89527A00F2C9592CF7FE7DFB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2E17907AF176E8F017DBA35163551D37</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIImagePickerController+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIImagePickerController+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2E4A651B3831DC039C0967839B8DE460</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8D3FD3990B8A1E9548CB62F43886EADA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2E8AE45009EAF83A18B9DF5D362ACDDD</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>FE463EC4F9832060D985F73596AD1F98</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo/Pods-RxGesture_iOS_Demo.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_RxGesture_iOS_Demo</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>2EA5E789256C909EFAB76C6238E9F905</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>NSGestureRecognizer+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2F12CA77D6F2C4B36E0E751A89004250</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RxCocoa.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2F2E1B3CE08387E078A0F574EAEF69E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FB5C6A9BAE45FFA2C75DC00EC9F9430F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2F4CB61EB466CCEAFBC662A76FE12D81</key>
-		<dict>
-			<key>fileRef</key>
-			<string>02A10A251161E99CA06BFBA191386FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2F709B0640631738B641635327262486</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/DelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2FE889C233DB3D6EE9B795A6B49DEBF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>731149DD4332983A51195DAE8684A126</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>303BA170CFDE25D980D0B4DA54BDAB58</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49FBEB4800AA72C5B24F339E2CE4492A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>307539268B403C5527AD2CAC86EEF51B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9D04517DD6AD2781E4CB927E673828D5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>30EA89C837F36EC0047FF48329CDB9DF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1371EDFFD119B102C16B66F5769F97F0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>32333103781E0D7296DE45160EFFCF8A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>LockOwnerType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/LockOwnerType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>32CC0E764B6FDD289813E6A11F422622</key>
-		<dict>
-			<key>fileRef</key>
-			<string>26F86A42574378E3C19BB20A1D4F6EE1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>32DB01547F7219DFA5AFF3C2A27DC685</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIActivityIndicatorView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIActivityIndicatorView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>33A5CCFF7C755C16BD3B5DB4FFE1F88D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>MainScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/MainScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>33AEE3A4B80BC6D382A80C251AD174C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FDA6B4837F238135EDBB1FD219AC21E8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3426C8436E0E44F1E70A1F7BC6D4BF63</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Reduce.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Reduce.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>35A0DBDABA33B8F9D4E26D70E7FE4DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>223D2D9A89527A00F2C9592CF7FE7DFB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>371997EFA02B3641F6F5DCA3462F231D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>InvocableType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/Internal/InvocableType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>371DDD0CEF02B7460E792887795AE23C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F7C711FE0E199D267B5A4E427D1FF097</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>377230FDD0CDD270BFF84020197D953B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4B57D8DB71BDAB80D01EB772BB8B51EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>37B0B8B080F1E6B923BEFBBF2DC5B11C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AddRef.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/AddRef.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>37DE1A019926E248B0F8C4BFA0957231</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa</string>
-			<key>target</key>
-			<string>9B0124864FA21CEC6CC3F9B3C55B6F65</string>
-			<key>targetProxy</key>
-			<string>9B6B4A1F1ED7FC887699E49A2A6262A4</string>
-		</dict>
-		<key>3804ADE6554A61F56E0FCD797E6D3084</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SectionedViewDataSourceType.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/SectionedViewDataSourceType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>381606C2C2D281EACA05C8A7EE991154</key>
-		<dict>
-			<key>fileRef</key>
-			<string>442E13A5AA3E5B956BF394857AB8456C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>383E8395E05602750FB92C87A2FDEB92</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>PanConfig.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3855C276EF7C6BB8BBDC137EA29C5AE3</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>969EF9A054D7A4FF9D52EC47F03E29BB</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo/Pods-RxGesture_OSX_Demo.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_RxGesture_OSX_Demo</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>3871A7C8372F1322E306860D1430882B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Cancelable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Cancelable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>38B3C9CDAAF67C93B531598DCF0ECC15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8F88D395752826616234A8383CBDCA3D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>38FFA225D5C51394D69115651C840EB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8F6F72CD5B62C5C3465BA5E974A333C1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pod</string>
-			<key>path</key>
-			<string>Pod</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3910FCE5221CCE106E07A99766F29D92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>66A938D2640AAB94C102006232D3177B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3923CF81B57F0AB60F4DE73C980321DD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Event.swift</string>
-			<key>path</key>
-			<string>RxSwift/Event.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>39BC07ED0F9C8237F0CF879CB5617181</key>
-		<dict>
-			<key>fileRef</key>
-			<string>41691D1578A4288F5D547260BF7422E4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>39FD8BDAE7CFD0A590BD823D434061A3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>70767CE5090AA6DBA27615A97E5975B2</string>
-				<string>9505DB71A910A7EA4A2BC2F348605F5A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3A847199C59581AE111ED00A7096043A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Queue.swift</string>
-			<key>path</key>
-			<string>RxSwift/DataStructures/Queue.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3A8C262F7B62C28B263F49AACFDFAB2D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>KVORepresentable.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/KVORepresentable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3ADD86DB658ADA7B22F4A9E9D1DA25A8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SynchronizedOnType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/SynchronizedOnType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3B18CE2FF2F45E60306F01D5887056D3</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>D7D2E8A3E11B6A93694AEE6F34218DD3</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift</string>
-		</dict>
-		<key>3B396FE81D2359AEF6D965CBD9818B8F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>419FD89DFCF42A6ADFE86D2D84B0EA46</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3B60F86E57C6E0B5EB1C16329497CA38</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F5079F022D850EE97985FE670AE654D3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3C6C162A5F021385835632E3EDB7CC09</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3C7AC628FB1EABCBB60604EF5F9E9DDB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7E897AFACD8C7C5E2A001D27DE0B4618</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3C99CE41C2C08F13D0EFB93F9F1AA297</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIScrollView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIScrollView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3CB24918AFDA96F22951E15B52F35A8B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSTextStorage+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/NSTextStorage+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3D1D85D88F45DA1940997764A3F22DA0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxCLLocationManagerDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Proxies/RxCLLocationManagerDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3D3655EA84BA51E653305BA5C757DEDD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CAC81FC6ADF84CBF9D24DF18F08820B7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3D5F0C9794F6E7E5EDE3E81BB3D21943</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIImageView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIImageView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3D98B80CA17B506B8C1B759D6A10E049</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C6B788D60B66AC712BFEF712D9BE4B2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3DC2B0E80E48647EAF1B31B4333EE75D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9D76728BF899DC869752E1AEF92F2522</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3E11B5F9407F2460BF507A031F543A31</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3E2ECDFC62B33F044E1AF48EB320DAE1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC31759D90FFBB778349105CD32B82A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3E46C8CA6BBF11ADED61F1E96D33D598</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSTextField+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/OSX/NSTextField+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3E98F8FEECEC2DD9F966C9D3E8807071</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Range.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Range.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EE67AD4EF9BB7255F12A8E1ACF59F43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9D76728BF899DC869752E1AEF92F2522</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3EE7A1AD2ACB8E5B50341976B1316CAB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8F0081C0EB913B4A12C9BA7F9E2C44CA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>40278FBAB194366C10D902746F0AEC7B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>A0F6D25550D0AB1122728E0E202E9B2F</string>
-				<string>A8D37F4EA054BE484E3BB6DC1A471493</string>
-				<string>DCA27732462FA9070AE710D9A361ADA0</string>
-				<string>0CE1F2ABB8602030A1F03084D04D59C5</string>
-				<string>72D0FD90034EB33EA0C92656D7074D46</string>
-				<string>EB04FF1B2FE87A99D524B3A353ADC3EA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>40731FA149D0C969EF2ACC2B814AAA39</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>41262CC4216C45247331AC963D084351</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>413C9E34B2F9D258BD62EDE945AEBE45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>674637809C1638D6E46627D0A7363E43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>41691D1578A4288F5D547260BF7422E4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DistinctUntilChanged.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/DistinctUntilChanged.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>419FD89DFCF42A6ADFE86D2D84B0EA46</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ScheduledItem.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/Internal/ScheduledItem.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>420B2B089843D05295392FFE1944FFC5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7BCED313175C4FDCE4ABF2985910FD43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>421A99241D4A19BC0384E070B6F733C6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FDEB61CDD7978740C1A32E03C8A96C40</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4243ABB4D6D5A1F0E3F004DD880FCC0B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CF5F9B539C916CEB13C073BD9B8706C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>42656EE65DDFF8396FEC9E28CDD0F922</key>
-		<dict>
-			<key>fileRef</key>
-			<string>477AECB674F89335ACC974874BAC99FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>42922C460C6B4921C335F9A0AB78966B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AsyncLock.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/AsyncLock.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4367F29A7CAE5D22120821D3736AB6BB</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>82A721AFC5D1B757D919FEC84F9FEF74</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxGesture</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>442E13A5AA3E5B956BF394857AB8456C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Never.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Never.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44538290913B42364D613A687800DA35</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>9D33872BAF4DC5FEC16683ED5494A07A</string>
-			<key>buildPhases</key>
-			<array>
-				<string>B3DB15563E7138CDB04ED4FEE30F9C0B</string>
-				<string>955FA3AF691A7749E601D60274BF0519</string>
-				<string>15A306E295D2367B200DE30C17839B09</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>8F7CCA301B616F7D8D91666A274C9185</string>
-				<string>D13E9BB839200D5CD261004AF41268D7</string>
-				<string>086E33B335E329AF6B3E4840A5067F05</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_iOS_Demo</string>
-			<key>productReference</key>
-			<string>DBD5C714DE2DE3862DE6DD9ABF4BA0E0</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>449F0019DD1F3E76574EB8C06356C328</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DelaySubscription.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/DelaySubscription.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44A9E2D9BDB77A290A874AC9B82CA058</key>
-		<dict>
-			<key>fileRef</key>
-			<string>10EAC6560D0E865FC286D0B2CEB21F8D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4532A8C74BD6D971D4ABCC991604D0B7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C3923EA7357FC6223BC856AAE0F07580</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>455E80A5EA99580469518024869EA1AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3D1D85D88F45DA1940997764A3F22DA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>45EC70652ECAA2EB6A5CF971D91B21FF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSSlider+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/OSX/NSSlider+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>46DD1AB167A06B315005919A9BD6E8B4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ControlEvent.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/ControlEvent.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>477AECB674F89335ACC974874BAC99FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Logging.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Logging.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>478E666AFFE284051B53DF3BCE11FCCD</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>153315CB7CE0328B96834073C4C53691</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>47C71957DC7BADC013C58987277C1BD2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>784DCD30FFABD70154CB39E13ADC428B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>48EB43C260994DB39FF711D96FB30B66</key>
-		<dict>
-			<key>fileRef</key>
-			<string>46DD1AB167A06B315005919A9BD6E8B4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>48FDC28F367EE164320F7C40A5BBEF6A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0FED2EC4C912C80F8F0A4FE9E545CB4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>491AEE4FE3195E5CA1225E6294EE1D43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5DC848B1D95281036D21CC324D052753</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>49FBEB4800AA72C5B24F339E2CE4492A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>_RXDelegateProxy.m</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RXDelegateProxy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4A2B40CC335CF4F90488701FB34D321D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ConnectableObservableType.swift</string>
-			<key>path</key>
-			<string>RxSwift/ConnectableObservableType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4A6886197AD7FBF1B3FE9A919B412C2A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CA440FABEECC06934002C5B7DFFD96C3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4ADCF9F5D8C0D7D8D78504E013A3F8F8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BFA9612F9925AA3168C6A101B4C99CEF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4B20F6146FF7DCA5A308859C677FAA81</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIControl+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIControl+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4B57D8DB71BDAB80D01EB772BB8B51EC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObserveOn.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ObserveOn.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4B860A00382AC06FCFA0D8436A433574</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4BA5080CDADDA1683B24B8F83BC42549</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4BBFDC66B5D6EDBA302DFCCD0A31BFD5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE379A21FCEBCEC0E0E426D9A123F760</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4BCCA5EA84D6D228F84102A8C62BC93A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CA682272C2916EFCE819012AA8F6F4C6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4BE2E8575BDC4E03E951EAE8E023EA7B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4CDA9865788B870D2E0C9631A55AD2FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ControlProperty+Driver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/ControlProperty+Driver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4CF423794EC5A22C04F574B184D00299</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2D0298A8428E79167215D2B8D70D16A5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4E0B27C110E6EBE3540BC9CDE16DAEBD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B0105A3A5AF33D1CF3973AD0CF4AEB9C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4E118E5BBB86F4E3D5BE4404D82BE6D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2D0298A8428E79167215D2B8D70D16A5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4E23CD6B7C23EABCF587E3A2E346290F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6E477EE3500BD6A016CE1951B989CF75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4F2D991B08E329A0337FB73CACB68194</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6399E931BEE7F5E5F5E04BAA0FC0DE34</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4F30C3F0E32A967675B65D48BEAB63A4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>89361C46E5D991265A6D4AECA7F2EAC4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>4FD268B8698165B5E6A0F33480CBBC33</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E1C544817D76E71D828DB3AE0EE5DFA3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>503E3338DF4E754C7E55F6C3B1E3E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F52B7AE23C229717D736C40F90B8D574</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>51C2DEE2E38271654A307DB0A57826FB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F86FFCA66ED86F404880F6B796F87F05</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>521A807C1287A4736A5185E17EDD0D0F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift.modulemap</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5282FD9C9A97C069805A7E22A42BC5A8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D0E9E99E1790D8207298D944DDA5D4A2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>52DE9731E7AB29C0A4F4994F544D31EC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DisposeBase.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/DisposeBase.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>536AE1D5281359DEF6F7890B09F1B40E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>283198B3A1BC9C9C64AF8776DF9D8602</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>53C9EC191E217693F417F3F3D5BD7E43</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CAAFF37D2CE77D76494B7F42ABF4792A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>53E085BA27253B4EFEDD426526E4A96A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Bag.swift</string>
-			<key>path</key>
-			<string>RxSwift/DataStructures/Bag.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>54133C9D54D6BD5ED81DAE23B47861CA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>KVORepresentable+CoreGraphics.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/KVORepresentable+CoreGraphics.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>541C9D6E1A995FF9AC9ADD3FB982BCE3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CE5313DC68E5A2FFE47DB9B6FC673E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>548BFBF4A1720DBCC0CDA20A3FC5F98E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8614B5BCCE597A517451A65FDCCF091B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>54D5A7B71E1199F308A12D92BD355DD0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6CD4E7DF61DAAA84A22AB05AD877367C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>54F425529CB9BBD2E9204457CDBE6EBE</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3855C276EF7C6BB8BBDC137EA29C5AE3</string>
-				<string>55620F726CA0D03B143CFF89E8A6CF77</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>55620F726CA0D03B143CFF89E8A6CF77</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>0BDB8D850932A64821E98B8CF500069E</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACH_O_TYPE</key>
-				<string>staticlib</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo/Pods-RxGesture_OSX_Demo.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PODS_ROOT</key>
-				<string>$(SRCROOT)</string>
-				<key>PRODUCT_NAME</key>
-				<string>Pods_RxGesture_OSX_Demo</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>55803E192FDF33FACEB82F80810AD284</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B0105A3A5AF33D1CF3973AD0CF4AEB9C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>55FD4EC3DFD48707D686FB0E30E9CFEB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8FB5D2484879C5E0D0AC211D9FC603D5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>55FD53BACDCF756892618AE87B40E110</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1541EFF54CE15FA4247A89DFB63268D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>566759A64E3D6143035478A562348AB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1A0E104B9153F15585DEC6956D497ACD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>569C76844EC991348E682B42B5153E23</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F86FFCA66ED86F404880F6B796F87F05</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>56FD49EF04E53934E3A49F07237ACAE7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DD6A6C23C63D4EB73064E6C68E20CD5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>573193BEB3DE9B1053800EFB15956A04</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SchedulerServices+Emulation.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/SchedulerServices+Emulation.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>57441D145F1BBDF326D2F35A2E722FEA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>41691D1578A4288F5D547260BF7422E4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>57A44A6F3687891BCF5CB0CDB1B1B7B7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73E7917F369F21F0188070F597CDE8E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>57E883ABEAA37C1D5A61A17EDF8C5CF6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A4F910A4EF4840DF1A5FA245812BEB1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>581AF6CF184D616CB20A4BF3484367C7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7D5E833F61266E85C52B9AFA5BDA55F0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>58ECEFE2F4CC184ABFE4A7BD4F63F568</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>58F145B976F3F9425E87313ECFD8E02E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3A847199C59581AE111ED00A7096043A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>593F579D1BAF6BE32C0C8EE70F88A84B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>52DE9731E7AB29C0A4F4994F544D31EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>59638383E4045E9D58DD49A2FAD59AB2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIStepper+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIStepper+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5ACBDD58CF47ECD8AD16A8E21B38D22A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A995AACF502C4037D6FBC4C6112ED3BB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5B14A01C0088D795DF56061F4DA5C947</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Variable+Driver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/Variable+Driver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5B3561537F5610E105E39CD7552E1426</key>
-		<dict>
-			<key>fileRef</key>
-			<string>19A8502B4392E2C35D5ECF8145E781DC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5BAD48CCE78D0D04C2596297ED9F3F97</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F748183552175B762FB45CE31A2F53FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5BFEA69A0915F6918164977C108CBBAF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3A847199C59581AE111ED00A7096043A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5C5A1CF70E522B6D4494C37B1C06F6D3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UICollectionView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UICollectionView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5C897B7691027D6EF6468F249FEF2833</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53E085BA27253B4EFEDD426526E4A96A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5CD5BCA415EF28EF307CECBA0621EAC6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C4122641759BCB149F3FCADD5C3268F7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5DC848B1D95281036D21CC324D052753</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTableViewDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5DCBAB0AEE38AA2F3D5A38E87AAE9EDF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CB32E46DA8057A3A622F29F4500772A2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5ECA4DA302151ED29AF5DAD33DF54FA4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3E98F8FEECEC2DD9F966C9D3E8807071</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5F569847A7107D9276E4725C50D0916D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>PriorityQueue.swift</string>
-			<key>path</key>
-			<string>RxSwift/DataStructures/PriorityQueue.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5F73DCC6D3F37BDB0EE4D0E020E4901D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5F9E2936986466A91E3AA1E822C6D3F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>72024E9C45ED7ABA10282FBC2A8B6CC9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5FA173D102727E0176EED982ADA11269</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIDatePicker+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIDatePicker+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5FA6793E8440943D0A3CE5EC20DCC7FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Window.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Window.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5FC278E77933E0D1F364DBD2B0A24180</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ElementAt.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ElementAt.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>60D58A4919924C9ED9BC875A2866FBDE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5F569847A7107D9276E4725C50D0916D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>60E0E6A55FB93D1F65E4691E05F2047B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>680753ED29B2B36844E7BF1D3EC725DE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>60F618BDF7BC2AC6CC2A49F4069E5944</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ConcurrentMainScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/ConcurrentMainScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6125CFE9D1577552DB75431F0817A868</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>613CFDD9885D7CC54BC0041A8B2E9FE8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>614365A9E4840470AC452C75DD2858EC</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>FFE6FFDA3FB700D8A1F431F6BE633F21</string>
-			<key>buildPhases</key>
-			<array>
-				<string>6AB24B3D46574156573F755E7B5C864F</string>
-				<string>D874BCA6EE22322AFBF24C21422A224D</string>
-				<string>0BBB68551EADF40B6394870505DC681B</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>BC0F59D8DF7183BCA7D0C4C53E1BC98D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa</string>
-			<key>productReference</key>
-			<string>1F19AA9E3785650C8EB42205C1EC4C29</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>6147FC5841082B8D142AE6914FB00B7F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>226B5AC3BB6D95D9409C54D83CFBBDD4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>615ABC9784F0410A0AB3F458224F9374</key>
-		<dict>
-			<key>fileRef</key>
-			<string>784DCD30FFABD70154CB39E13ADC428B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>615B0141A00A2139932548F59332833A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5B14A01C0088D795DF56061F4DA5C947</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>625F7B91B276D9AD6E32248D4F1F4861</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F60D78F33A072FBB5C97E5841B867C77</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>631A1DD20311EE54BC795DF915327298</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BC5384AAA357E269F58CCF248EF00C45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>634F4ECE00431123C06FD52C27501C64</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>name</key>
-			<string>Info.plist</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxGesture/Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>637B39D283F2B3C1CE39F900E3526F2C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>638D81BBC0A578B83C471D806B095768</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RxSwift.framework</string>
-			<key>path</key>
-			<string>RxSwift.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>6399E931BEE7F5E5F5E04BAA0FC0DE34</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSLayoutConstraint+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/NSLayoutConstraint+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6487EE29EEB4C56EED2333CF8AA5A55D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>64F36D028C5B6F656BB7F9D8DE2CB4F4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>C4C8C36FB51CB1A5BEED5AAF41603DE2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>656AF484ECD477CE254E68B0845BE284</key>
-		<dict>
-			<key>fileRef</key>
-			<string>33A5CCFF7C755C16BD3B5DB4FFE1F88D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>659676DA59F72833BBCCB9853A143C7E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53E085BA27253B4EFEDD426526E4A96A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>65C5DCE08601B273DE0CF84D2AC1CA7D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTableViewDataSourceProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>65D1EB659125EA3969D59014B9F4E1A4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Producer.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Producer.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>666CEAE2C63819EF5FAC680D6243A456</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Sequence.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Sequence.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>666EC55287F6C67AE52B6B460EAA059D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3D5F0C9794F6E7E5EDE3E81BB3D21943</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>66A0A91B504135AF2AECC09049FA49A3</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>38FFA225D5C51394D69115651C840EB4</string>
-				<string>D20BEAC539F3FDAE5D9C0E1DD60CD4C4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RxGesture</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>66A938D2640AAB94C102006232D3177B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Timeout.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Timeout.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>66E7C9EF14FDB3049AD6DBADD3D5F546</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FC3A97DF6DC20E8FA7115AF427A1FDA3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6744289BF897F4D0525E1819B31C7CA9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1371EDFFD119B102C16B66F5769F97F0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>674637809C1638D6E46627D0A7363E43</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxScrollViewDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67CAC0F262FD2A9FCA59C6463798FCAF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5F569847A7107D9276E4725C50D0916D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>680753ED29B2B36844E7BF1D3EC725DE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>VirtualTimeConverterType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/VirtualTimeConverterType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6852FC5243339B784056CB637BC1FEAC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>02A10A251161E99CA06BFBA191386FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FDD0E090F8DA37A3283ABA5E5DEF50</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F90193FA637C5E3C76DCF1888950DB2C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6956E7A76E55AB0986EE76E8CDF2AC47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6B52DF800B19E074DBC494C3F9A24063</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6982B8E4C6FF27973BC4186FA1B03D23</key>
-		<dict>
-			<key>fileRef</key>
-			<string>449F0019DD1F3E76574EB8C06356C328</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69AC08DF9FDE31998C7869EBAF62B3AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>70AF53C1EA75011D56334E4AB4C72E91</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6A2E2C219DFF6D32C16239EE310606E8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>236983DA69E6A12F58775605239117DE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6A7E2B288AEF9F04DA4D3DAF5B40E7F1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Repeat.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Repeat.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6AAF23825904D6DFC9229E6C7BD8CA4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2E09F8FD785663489A532E8A69164E9C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6AB24B3D46574156573F755E7B5C864F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E60ED422014F151D85A4DE0D0090BED2</string>
-				<string>A1435F6083BF431922428FD10EC7A363</string>
-				<string>A251D2B4AEC83C9A367126EC5FBD3154</string>
-				<string>9FE76B6763DDF6DDE5A227F3FAE42324</string>
-				<string>D2CB38767A2E8CD22E0C3F424ACDC178</string>
-				<string>7E1DAD3A8BF695335D0FCEC77C7B2629</string>
-				<string>48EB43C260994DB39FF711D96FB30B66</string>
-				<string>7D3EFAC4F3A7F0FFD1AF360CCFE9CD71</string>
-				<string>69AC08DF9FDE31998C7869EBAF62B3AF</string>
-				<string>9A72425633B1074724BE4AD9E253486F</string>
-				<string>1B4A8D83F816BC448322BC0057DAA019</string>
-				<string>05B217FDEBD05EAF43320C9D44E5D002</string>
-				<string>A741711B1571F9AEDC76DF57CDCC049D</string>
-				<string>1897D796678C177CDE2943A913694DA1</string>
-				<string>DDF30573D7664E73624011D0DAD860C5</string>
-				<string>1DEA721BCEC873F79234C5E63F2548B8</string>
-				<string>BCDAA38E7E8D4116EA76D257BC319C4D</string>
-				<string>83C2F4F5EF675EAC0897B942201FF004</string>
-				<string>541C9D6E1A995FF9AC9ADD3FB982BCE3</string>
-				<string>581AF6CF184D616CB20A4BF3484367C7</string>
-				<string>B32070E942F1B441075C288B6D0ED075</string>
-				<string>BFCDB1F0CB2317AA6C5C494CE54FE8AA</string>
-				<string>AC8E5C01404D499F26CD4C999E341E12</string>
-				<string>42656EE65DDFF8396FEC9E28CDD0F922</string>
-				<string>F86837682196263E9D5F287348EB7B59</string>
-				<string>BF180276153CFFF40164206E6A3BEDFE</string>
-				<string>BA8B75DCD8B33C4AD231FA051BF3EFC7</string>
-				<string>5F9E2936986466A91E3AA1E822C6D3F5</string>
-				<string>0F0D9C24C0E44E57008ED781A6A9540A</string>
-				<string>421A99241D4A19BC0384E070B6F733C6</string>
-				<string>F300A6D9B9E5AE90DC83258DC5E63E53</string>
-				<string>A58ACD233E056D2610BCF047FC636DD1</string>
-				<string>01E61E8DC081EA6C0009BBD7057D29C1</string>
-				<string>4CF423794EC5A22C04F574B184D00299</string>
-				<string>BC99BB8FACD40E788CCAA7BDFBC77498</string>
-				<string>F0E9F066503AC19C46BC1AA084BAFD15</string>
-				<string>4E23CD6B7C23EABCF587E3A2E346290F</string>
-				<string>BD376A3A84020AEE9C9152B28EC0E881</string>
-				<string>9EFC8B35852B90A6EC3A9D47486CA105</string>
-				<string>38B3C9CDAAF67C93B531598DCF0ECC15</string>
-				<string>E8501FA1970C16E7C772C02D8159FC00</string>
-				<string>5BAD48CCE78D0D04C2596297ED9F3F97</string>
-				<string>413C9E34B2F9D258BD62EDE945AEBE45</string>
-				<string>23978FC6352310883C0A2876EB707671</string>
-				<string>C4C47BAFEE1709C11AB5145DCF02D960</string>
-				<string>05BD51B2599DFF8C9D77DF9CCAB2F8CD</string>
-				<string>491AEE4FE3195E5CA1225E6294EE1D43</string>
-				<string>260BDDD7A70035E73256485415DEEAFF</string>
-				<string>18570A91E717C6ACB651EF74D1504147</string>
-				<string>AF308452C9E3E4F62252D19FBD918CA7</string>
-				<string>0CBCDC693500CA15D126A035DB4D4367</string>
-				<string>9A67BEAAD395C1FAB9421B85C177D655</string>
-				<string>BD94DC753DE37948A6725AFEB246FC78</string>
-				<string>3D98B80CA17B506B8C1B759D6A10E049</string>
-				<string>2B0D27F069E8F0E701A6C9CDD3F57504</string>
-				<string>C4E0857D9EDB53394B79170F060B50DD</string>
-				<string>DFF7AC2C01AE58822F964F3F439067AA</string>
-				<string>23E941CEBFF4F79C8A915B8ED8FD1827</string>
-				<string>D14C2BC5CCDB880C6B15F4858C458EB1</string>
-				<string>B8FD0CAA10337CBD9FC73B16905717B6</string>
-				<string>BF46C30F6DA5B7E88423642828CEEDF3</string>
-				<string>C81E9FE86F69EE1D3FAF2AC827103164</string>
-				<string>666EC55287F6C67AE52B6B460EAA059D</string>
-				<string>0C47F7A3A711DEF2852287E958912400</string>
-				<string>0305F269FD99A7E9B15020CDE7EC04AC</string>
-				<string>8DA8A901EE6CDF0AF1D59CC4EEC1F3C4</string>
-				<string>08D2BF0199EBBCEC535A63481EEA6E5E</string>
-				<string>8E73D62412624AB799DE8F75CC24F0F9</string>
-				<string>07537B3412788F76A1CADAE162264580</string>
-				<string>FCCAD7210551E7E315057FE92B71710C</string>
-				<string>A6985271C67D3D39671F6594CC636975</string>
-				<string>73F6711DED2B6CDFA88C34BBB7283730</string>
-				<string>1A6B5613B12EDBA017A9204D949A4D2A</string>
-				<string>4ADCF9F5D8C0D7D8D78504E013A3F8F8</string>
-				<string>789C95EFBA949A2C03982A2E9D62E0DD</string>
-				<string>54D5A7B71E1199F308A12D92BD355DD0</string>
-				<string>860D3C64CC7EDA6718F7158ED0F613DB</string>
-				<string>D4471926F81D20E92AAC8F5D7966020C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6ACDA50CF7E4AA489A05B943886D1329</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E1C544817D76E71D828DB3AE0EE5DFA3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6B52DF800B19E074DBC494C3F9A24063</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>BinaryDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/BinaryDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6B702CBA3187CA6D991CBE76351837FD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8806CC77B1040592A24B4F57B756C9AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6B81B26818BFF79D9DE0909B20812BE6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FBC2B3604E156C2B39FB243BDBF5FBDC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>6C8881718CC15265D09C41CBB10B7E9E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>71AFAD963301C46BC7BC87E5B3D2F396</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6CAB49D89624A04E4152A06D8E5AC124</key>
-		<dict>
-			<key>fileRef</key>
-			<string>32333103781E0D7296DE45160EFFCF8A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6CD4E7DF61DAAA84A22AB05AD877367C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UITextView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UITextView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6D2AD61B12BFF5101ACA654F7586EFBD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A9BF5397CE64E09EB5C37D737FA40398</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6D7B567D2F85E5F4E1BEA8ECF23B62CC</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>762B97592028B0AF475F397928ADD638</string>
-				<string>B8B9F1EB2BCB1B79E946A0A557D77AB1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>6E0C7DD780E181D0F5EB28D77EDB199C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SerialDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/SerialDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6E477EE3500BD6A016CE1951B989CF75</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxCocoa.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/RxCocoa.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6F0F0AF42A8ACC55406B4D1B3531B75C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6F1701065113278B4F9EA93F2C4D30AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>032DD707905DA8D3C57277EF878F3240</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6FC7A3AACED3A13E19B113FBFFE5F6A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0047D7C07D4E7168D66A6B195B20AF58</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6FD15299911C10004D6C338D4883BEA6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ImmediateSchedulerType.swift</string>
-			<key>path</key>
-			<string>RxSwift/ImmediateSchedulerType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6FD602910C6A4CCF48277C86A835C39E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6FD15299911C10004D6C338D4883BEA6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>70395B0C308DEC6A90B53EDF20802995</key>
-		<dict>
-			<key>fileRef</key>
-			<string>245AC5100739C5A8E44FBFE74CCCCC12</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>703A91CA61086D71F395EB4300699E18</key>
-		<dict>
-			<key>fileRef</key>
-			<string>19A8502B4392E2C35D5ECF8145E781DC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>70767CE5090AA6DBA27615A97E5975B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9D76728BF899DC869752E1AEF92F2522</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>70AF53C1EA75011D56334E4AB4C72E91</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ControlProperty.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/ControlProperty.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>70C8BBEADC28B99A09E31C0BC5FE57FD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>OperationQueueScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/OperationQueueScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>70E1CCCB0F08BF258F53C425F111D784</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C25308CFE7CECE3CF7E9AC0EBBD33AF9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>713CD0C782C89D147C113A835FA5BD81</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Zip+arity.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Zip+arity.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>714C5305FFAFC2F0793D969801E49179</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NAryDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/NAryDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>71AFAD963301C46BC7BC87E5B3D2F396</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Driver+Operators+arity.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/Driver+Operators+arity.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>71BC036D660D42931AC03ABF46519321</key>
-		<dict>
-			<key>fileRef</key>
-			<string>226B5AC3BB6D95D9409C54D83CFBBDD4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>72024E9C45ED7ABA10282FBC2A8B6CC9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSObject+Rx+KVORepresentable.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/NSObject+Rx+KVORepresentable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7213CFEC67C3B1D54FD43442BB4DD2F8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>DBD5C714DE2DE3862DE6DD9ABF4BA0E0</string>
-				<string>E0BD34020D1CF5E582610A08BF646C57</string>
-				<string>1F19AA9E3785650C8EB42205C1EC4C29</string>
-				<string>1F19AA9E3785650C8EB42205C1EC4C29</string>
-				<string>8BC1538A9C562465360DC7DEE22C8AB0</string>
-				<string>8BC1538A9C562465360DC7DEE22C8AB0</string>
-				<string>638D81BBC0A578B83C471D806B095768</string>
-				<string>638D81BBC0A578B83C471D806B095768</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>721A84CDA8546C0571A414907F59A60C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FA6793E8440943D0A3CE5EC20DCC7FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>72A3310CDED6F0B1AC6B42A981CC578B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ControlTarget.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/Implementations/ControlTarget.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>72C524E7B71E56E69737978A30762BD0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A0F993C4C6D6C90DB6204A41E10A910E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>72D0FD90034EB33EA0C92656D7074D46</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B938000B6A988DBB740EE2ED9F411571</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>731149DD4332983A51195DAE8684A126</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/OSX/NSView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>732C1BA4FEAEBF02986DD3EE64224F80</key>
-		<dict>
-			<key>fileRef</key>
-			<string>777BF9DD554FFC95F2DFA576184620D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>73E7917F369F21F0188070F597CDE8E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>KVORepresentable+Swift.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/KVORepresentable+Swift.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73F6711DED2B6CDFA88C34BBB7283730</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F0C4B9D95966A3DD638408DD2AC9A1C1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7418514157E5C688CE763A5F254CF413</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A995AACF502C4037D6FBC4C6112ED3BB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7434BE3361F7A52BAE1FC831D881C933</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F52B7AE23C229717D736C40F90B8D574</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>74B6F38577B25B297F2010325DC77DD3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D91B8FB88CC735C3CC651A2DDAA219E5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>74EBCCB5B3263EDA7A8F3F071712CAFD</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BC5384AAA357E269F58CCF248EF00C45</string>
-				<string>26AAE4981F2B2A0B345D49C6FFF3F191</string>
-				<string>1F4249BCB52EA315CF45C8AF750220C3</string>
-				<string>49FBEB4800AA72C5B24F339E2CE4492A</string>
-				<string>EB39ED08E4C74181954C6B42D69F7FB7</string>
-				<string>8BF27BBCB2AAD5C679581C38EE2DC185</string>
-				<string>CB48DAD7D5163991153C05BD30040B6D</string>
-				<string>7CD8DFA3BDA378BDC5FF885379349130</string>
-				<string>0AC1F877E92090E34F5CE2FB79F4629D</string>
-				<string>46DD1AB167A06B315005919A9BD6E8B4</string>
-				<string>E058D4EBE0ECDD108B8578F0C62D285A</string>
-				<string>70AF53C1EA75011D56334E4AB4C72E91</string>
-				<string>4CDA9865788B870D2E0C9631A55AD2FC</string>
-				<string>72A3310CDED6F0B1AC6B42A981CC578B</string>
-				<string>8A4F910A4EF4840DF1A5FA245812BEB1</string>
-				<string>2F709B0640631738B641635327262486</string>
-				<string>D12DB9FC05ECEBD079763E18E22438A0</string>
-				<string>283198B3A1BC9C9C64AF8776DF9D8602</string>
-				<string>DE379A21FCEBCEC0E0E426D9A123F760</string>
-				<string>71AFAD963301C46BC7BC87E5B3D2F396</string>
-				<string>8A12623F1AB0752800B1DB10DF0417CF</string>
-				<string>0278F3FA193A3C83B14B2E3F9ED87E2F</string>
-				<string>9CE5313DC68E5A2FFE47DB9B6FC673E6</string>
-				<string>7D5E833F61266E85C52B9AFA5BDA55F0</string>
-				<string>3A8C262F7B62C28B263F49AACFDFAB2D</string>
-				<string>54133C9D54D6BD5ED81DAE23B47861CA</string>
-				<string>73E7917F369F21F0188070F597CDE8E6</string>
-				<string>477AECB674F89335ACC974874BAC99FC</string>
-				<string>FDF08F5702058168441B64713EBBB29D</string>
-				<string>018B5C8CFEFFB40F36662FA6FE88DAF1</string>
-				<string>95792EE983BD8CEAA248950D147179F7</string>
-				<string>1769EE025DD222C127D3D32B83C90BC0</string>
-				<string>6399E931BEE7F5E5F5E04BAA0FC0DE34</string>
-				<string>777BF9DD554FFC95F2DFA576184620D8</string>
-				<string>FDEB61CDD7978740C1A32E03C8A96C40</string>
-				<string>72024E9C45ED7ABA10282FBC2A8B6CC9</string>
-				<string>CCFDBBFF08F74F9511DF21F873EABE86</string>
-				<string>45EC70652ECAA2EB6A5CF971D91B21FF</string>
-				<string>3E46C8CA6BBF11ADED61F1E96D33D598</string>
-				<string>3CB24918AFDA96F22951E15B52F35A8B</string>
-				<string>F5079F022D850EE97985FE670AE654D3</string>
-				<string>731149DD4332983A51195DAE8684A126</string>
-				<string>2488AC35E99BBB5538B1BD95F7655E94</string>
-				<string>2D0298A8428E79167215D2B8D70D16A5</string>
-				<string>3D1D85D88F45DA1940997764A3F22DA0</string>
-				<string>89361C46E5D991265A6D4AECA7F2EAC4</string>
-				<string>6E477EE3500BD6A016CE1951B989CF75</string>
-				<string>1E30F06ECF68CB0C48EA50C7EE7B2433</string>
-				<string>935D94469ED0B54EACC3A4C0F12B4646</string>
-				<string>8F88D395752826616234A8383CBDCA3D</string>
-				<string>AD57AA83FCA2E0F8E94E8CAFC455341C</string>
-				<string>F748183552175B762FB45CE31A2F53FC</string>
-				<string>674637809C1638D6E46627D0A7363E43</string>
-				<string>1A2DA45028046C38FA03EA5A688E9AB4</string>
-				<string>65C5DCE08601B273DE0CF84D2AC1CA7D</string>
-				<string>F2C2A9E19936B336BC0C7AE82D875826</string>
-				<string>5DC848B1D95281036D21CC324D052753</string>
-				<string>D859CDF029BE59A16868AB0E614D41BB</string>
-				<string>DE4BF2809DFC533229426FC2B1D4AF91</string>
-				<string>FE1DCEC4B3D1DAFFC879A8BAB2E0B13C</string>
-				<string>06E0F99179E5CCB68C4721ECC9703E40</string>
-				<string>3804ADE6554A61F56E0FCD797E6D3084</string>
-				<string>32DB01547F7219DFA5AFF3C2A27DC685</string>
-				<string>9C6B788D60B66AC712BFEF712D9BE4B2</string>
-				<string>F20316FCE33298DCDDE596E17F8ABF9B</string>
-				<string>CF5F9B539C916CEB13C073BD9B8706C9</string>
-				<string>83425313765F7ED109DC81D7BADC7B5A</string>
-				<string>5C5A1CF70E522B6D4494C37B1C06F6D3</string>
-				<string>4B20F6146FF7DCA5A308859C677FAA81</string>
-				<string>5FA173D102727E0176EED982ADA11269</string>
-				<string>8E3CECCCF5890CBE65780B3C8D44E2B1</string>
-				<string>2E17907AF176E8F017DBA35163551D37</string>
-				<string>3D5F0C9794F6E7E5EDE3E81BB3D21943</string>
-				<string>AEDB7B436E22D693CB5360DB88CE7450</string>
-				<string>2576CF8363182027D6275CCCF79BFF09</string>
-				<string>F9E699138D97A7B8FB51A1169458CC5B</string>
-				<string>3C99CE41C2C08F13D0EFB93F9F1AA297</string>
-				<string>DD0BF625CE8A09C228BDA4F907267DA2</string>
-				<string>9A2B0DA384E6A125B6430754BD9E8241</string>
-				<string>A7485BC75D5D55862531507EA811F6BA</string>
-				<string>59638383E4045E9D58DD49A2FAD59AB2</string>
-				<string>F0C4B9D95966A3DD638408DD2AC9A1C1</string>
-				<string>937967AE1F14874EF338B1B8F57AA23B</string>
-				<string>BFA9612F9925AA3168C6A101B4C99CEF</string>
-				<string>2CDEF5835D5C10A026F090259385CC21</string>
-				<string>6CD4E7DF61DAAA84A22AB05AD877367C</string>
-				<string>2DF76949F9A826C7D066D20516A6268E</string>
-				<string>5B14A01C0088D795DF56061F4DA5C947</string>
-				<string>E409A63713B84552678935C3B2FB066C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RxCocoa</string>
-			<key>path</key>
-			<string>RxCocoa</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>74F5E7BE653FC92CDD229EC32CBCDFE9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2C6AB6AEB9265AFCBF6B63FE10D75B45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>750B5432B0FF3138009F3EEA57AFE84E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DA6D897F503A3460A4E195622BACB277</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>752964FCFB788000B79D21627D4D737E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0AC1F877E92090E34F5CE2FB79F4629D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>754393E014D5DDCFD533E33A02544594</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>NSView+RxGesture.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>758C1D78FBE53E84387DB6ADD0076CEF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FDA6B4837F238135EDBB1FD219AC21E8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>75DCFE5F338EA7396929204D17363C5F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CB48DAD7D5163991153C05BD30040B6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>75E7B15E4542BBAB1CFDDDBD6EA1780A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A9BF5397CE64E09EB5C37D737FA40398</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>762B97592028B0AF475F397928ADD638</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>637B39D283F2B3C1CE39F900E3526F2C</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxSwift</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>76B114D443921B9C63AB12F9EE7AC8AB</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>613CFDD9885D7CC54BC0041A8B2E9FE8</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxGesture</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>771B9761981CCDDC31120956AFB6D6D5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F8B7F8C036BA9171F3B199A086D94A88</string>
-				<string>A486D9E086D5087509C0FA917C16E181</string>
-				<string>521A807C1287A4736A5185E17EDD0D0F</string>
-				<string>F613E3B025F9B61C1CAB05CA71EA6B22</string>
-				<string>E592BE42F6C322EF48759A3D652B83BA</string>
-				<string>784144428CC006C85BDB001BA7FC389B</string>
-				<string>9EEA1B9C1EA4C125354E33390B6E85E6</string>
-				<string>F788295A8CDD83CDBE32E83DFE9AF945</string>
-				<string>637B39D283F2B3C1CE39F900E3526F2C</string>
-				<string>58ECEFE2F4CC184ABFE4A7BD4F63F568</string>
-				<string>E32F9EEBC2569CC8B22C59582C0E2D35</string>
-				<string>B8393E60BACCB4386FBDC6A62A9FA561</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>772264D999738121516654B4232C27CA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C7E745319BCA81A3F171ED2C1DF23643</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>777BF9DD554FFC95F2DFA576184620D8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSNotificationCenter+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/NSNotificationCenter+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7783C8B43B0F83A3E122DF1748EC8CAB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B938000B6A988DBB740EE2ED9F411571</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>77A85EF82F6A93E9EBFCD97A800D30F0</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>76B114D443921B9C63AB12F9EE7AC8AB</string>
-				<string>99BCD2A0F6991CED214B3FE26A22B907</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>784144428CC006C85BDB001BA7FC389B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7847BFC1F539128C32E132CB47172B80</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DD670E6BA419147639CA62FC8C3CEDA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>784DCD30FFABD70154CB39E13ADC428B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ShareReplay1.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ShareReplay1.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>789C95EFBA949A2C03982A2E9D62E0DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2CDEF5835D5C10A026F090259385CC21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7908C1A8D99504533AC23866832E9706</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B54EEB7F3D9B9D4D2E5708405A57F65E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7968685A24D6C361EE9E76D7D17C454B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Creation.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Creation.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7980E42EC0632C1655018D3F9FF4FF00</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2EA5E789256C909EFAB76C6238E9F905</string>
-				<string>754393E014D5DDCFD533E33A02544594</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>OSX</string>
-			<key>path</key>
-			<string>OSX</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>79AB7F257D1569817E550D4098C2E58B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A3B83162A671B863092C509640455BB1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>79EEA13950D3C7E26EA2C570F80B66C2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>CompositeDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/CompositeDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>79F67FB9CB9E17F8CBF312FA0084EAB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>02736A0824ED21A5F170A055AAC18B5E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7A6AB5F92240D1411B8C16AA3601EC2D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F60D78F33A072FBB5C97E5841B867C77</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7B78DDBD2013D33F60F929243F25B565</key>
-		<dict>
-			<key>fileRef</key>
-			<string>573193BEB3DE9B1053800EFB15956A04</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7BBDD3EDB691FC01479A70C69E47CEE7</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>F613E3B025F9B61C1CAB05CA71EA6B22</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>7BCED313175C4FDCE4ABF2985910FD43</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Sink.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Sink.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7C0C813650AFCAACE69C0BBAF5A9D251</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Lock.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/Lock.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7C6A588762CF05921A56DE6635B89C5D</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>54F425529CB9BBD2E9204457CDBE6EBE</string>
-			<key>buildPhases</key>
-			<array>
-				<string>478E666AFFE284051B53DF3BCE11FCCD</string>
-				<string>2D670B044F667B3ABB1F4F604E72E380</string>
-				<string>28DB94F701EECB69825350684A061A4F</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>BC6C0360F2323A799BCA9C0911695482</string>
-				<string>9CA8E982B83600D9910D7D70B286823B</string>
-				<string>C381F6C0D2BF123EA57219C3E98C84C4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_OSX_Demo</string>
-			<key>productReference</key>
-			<string>E0BD34020D1CF5E582610A08BF646C57</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>7CD8DFA3BDA378BDC5FF885379349130</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>_RXObjCRuntime.m</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RXObjCRuntime.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7CDC591FE27EDF0166C359C990E9F4FA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7CE43A2B274B3A1C65CA161F632448B1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>371997EFA02B3641F6F5DCA3462F231D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7D3EFAC4F3A7F0FFD1AF360CCFE9CD71</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4CDA9865788B870D2E0C9631A55AD2FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7D5E833F61266E85C52B9AFA5BDA55F0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>KVOObserver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/Implementations/KVOObserver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7D929FFFFBCE37A90FDFAEDF52FBF97E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9D04517DD6AD2781E4CB927E673828D5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7DB346D0F39D3F0E887471402A8071AB</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
-				<string>05974E627F79103F55BF0441A036DC2B</string>
-				<string>B636038A1B7E8207534A0915F7BDD838</string>
-				<string>B70DB572A950F95B2749F85F2D2A4F31</string>
-				<string>7213CFEC67C3B1D54FD43442BB4DD2F8</string>
-				<string>8CEC25C86E13D26170D9C7A385DC74C4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7E1DAD3A8BF695335D0FCEC77C7B2629</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E058D4EBE0ECDD108B8578F0C62D285A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7E412D4C2839AA78A37DC16806611918</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0047D7C07D4E7168D66A6B195B20AF58</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7E53E34B09E745150E50C6A324601EB6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E7731A4628E596D95ACD0AFE6EEBBA43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7E897AFACD8C7C5E2A001D27DE0B4618</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Binding.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Binding.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7F089E4EA414B734ED9F56F71D01F01E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>F613E3B025F9B61C1CAB05CA71EA6B22</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxSwift</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>7F4253EEA0015AD9E0F2EDD399E50ED6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7F9306F3A8C6B18F1E89D3BFD4221F98</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4BA5080CDADDA1683B24B8F83BC42549</string>
-				<string>3C6C162A5F021385835632E3EDB7CC09</string>
-				<string>6F0F0AF42A8ACC55406B4D1B3531B75C</string>
-				<string>93F4DB97B25A1296A903B4E94A63FB61</string>
-				<string>D72318DBF092553E249C7DEA4BD4BEA0</string>
-				<string>068C90A9229762E4F318F6CD34B2ECF5</string>
-				<string>7F4253EEA0015AD9E0F2EDD399E50ED6</string>
-				<string>FBC2B3604E156C2B39FB243BDBF5FBDC</string>
-				<string>97E089F34EA8E281F450990124ADE867</string>
-				<string>FE463EC4F9832060D985F73596AD1F98</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-RxGesture_iOS_Demo</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7F9DCD3DE6178587C27AF8D985383E08</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>UIView+RxGesture.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>80464EA0B50C6A06A9C5061AA0E72B6E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Deferred.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Deferred.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>810CDFDD1F29B38A57A777A0E34E51F3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>815412E715BE08871E4C5ABC97006596</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EDBB3142C058BFF8F0B79E20C43D86F8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8267675773E498B54102DEDDB7B15C3E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>name</key>
-			<string>Info.plist</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxCocoa/Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>82A721AFC5D1B757D919FEC84F9FEF74</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>83425313765F7ED109DC81D7BADC7B5A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIButton+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIButton+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>83C2F4F5EF675EAC0897B942201FF004</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0278F3FA193A3C83B14B2E3F9ED87E2F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>83E43C0E90CB742D1536BB8DA28FC055</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3923CF81B57F0AB60F4DE73C980321DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>83E49E67B149F9FB070BFAC545DEC15A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DD6A6C23C63D4EB73064E6C68E20CD5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>847834D1DB009F49A71F9BE5F785B24B</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift</string>
-			<key>target</key>
-			<string>D7D2E8A3E11B6A93694AEE6F34218DD3</string>
-			<key>targetProxy</key>
-			<string>102827C3A99E45D1C6FDE5A5DBC0E68E</string>
-		</dict>
-		<key>847D340E4481EB953B56E987A8863B62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A12623F1AB0752800B1DB10DF0417CF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8526D54EBF04F2654F48E763F88A8142</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7F9DCD3DE6178587C27AF8D985383E08</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>856BEF17CF7475929D62A60D15415559</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>85B26A5D41DBB998BC91E988B0B68FFF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Switch.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Switch.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>85BEA7D91944470D6D27E8F8AFD5DC33</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2DE492C558DEBA31064661917BC71BE2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>860D3C64CC7EDA6718F7158ED0F613DB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2DF76949F9A826C7D066D20516A6268E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8614B5BCCE597A517451A65FDCCF091B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>867FB6D9CD5ADD06727AA1E89197078D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObservableConvertibleType.swift</string>
-			<key>path</key>
-			<string>RxSwift/ObservableConvertibleType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>87106C3E8834791259A7E930EF519CD2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4A2B40CC335CF4F90488701FB34D321D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8785D32B23307F4B79618A5F7856F44F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1541EFF54CE15FA4247A89DFB63268D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>87D45D1CEF140D8687BAE10B04EF8E34</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>371DDD0CEF02B7460E792887795AE23C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>87DD8E5189D29C2A58ADF3FB7B5B0FBA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E145F810DEFF07BCE812538BFA651708</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8806CC77B1040592A24B4F57B756C9AA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Time.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Time.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>880EC46B2EA4171F124091B6A8EEC9BE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Throttle.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Throttle.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8822B80A6A868B58E68512A9C1288FC8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>88598E8F88F0DAC9F2DA4B493925178E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C64491ABA744A4BD99C4CB1D733B5DA3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>88FC4A07660873918F076FF438E24176</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B594A1B0AF0D78EE827EB80F48CFEDDA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>89361C46E5D991265A6D4AECA7F2EAC4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RxCocoa.h</string>
-			<key>path</key>
-			<string>RxCocoa/RxCocoa.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8987DC4DFACCA1F78A94D60F1EDFC99B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>666CEAE2C63819EF5FAC680D6243A456</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>89BA35490BB928E75A9CC8E7A2FA3DDA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1A0E104B9153F15585DEC6956D497ACD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8A01F5D8032F07A5A0D80DCEA17D7282</key>
-		<dict>
-			<key>fileRef</key>
-			<string>383E8395E05602750FB92C87A2FDEB92</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8A12623F1AB0752800B1DB10DF0417CF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Driver+Subscription.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/Driver+Subscription.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8A47B3D1B773D68299EDABB9A4D54E96</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Variable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Subjects/Variable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8A4F910A4EF4840DF1A5FA245812BEB1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DeallocObservable.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/Implementations/DeallocObservable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8ABCA9D25D5ED7D25B873051B0E2BAB5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8AE5D75670141C6CD6BCBD346D5587AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7BCED313175C4FDCE4ABF2985910FD43</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8BC1538A9C562465360DC7DEE22C8AB0</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>RxGesture.framework</string>
-			<key>path</key>
-			<string>RxGesture.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>8BF27BBCB2AAD5C679581C38EE2DC185</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>_RXKVOObserver.m</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RXKVOObserver.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8CEC25C86E13D26170D9C7A385DC74C4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>7F9306F3A8C6B18F1E89D3BFD4221F98</string>
-				<string>23B972FE2CA4CA82B850AB93E1490E98</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8D3999B3B1E916D957A5C779A5EBB60E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D9F0A2FEE585A9018680D5769208A755</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8D3EEF1A053E268995FD7ED5169F02B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B94D6C7DD2DDCFDF47973632D61DB036</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8D3FD3990B8A1E9548CB62F43886EADA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObserverType.swift</string>
-			<key>path</key>
-			<string>RxSwift/ObserverType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8D75B23AA0082EE3BE5054DF283818F3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC31759D90FFBB778349105CD32B82A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8DA8A901EE6CDF0AF1D59CC4EEC1F3C4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F9E699138D97A7B8FB51A1169458CC5B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8E2DE5024F9792C19792D92B8B1D985D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>573193BEB3DE9B1053800EFB15956A04</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8E3CECCCF5890CBE65780B3C8D44E2B1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIGestureRecognizer+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIGestureRecognizer+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8E4DD36D597C752EBB6051DF7A6258A2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1F4249BCB52EA315CF45C8AF750220C3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>8E73D62412624AB799DE8F75CC24F0F9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DD0BF625CE8A09C228BDA4F907267DA2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8E7CDAC755EB5A725153296B2E243630</key>
-		<dict>
-			<key>fileRef</key>
-			<string>94E8B074971AF38C0412AE173DB4552D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8E9D487DFEA8015CA9E7123698C10196</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4B57D8DB71BDAB80D01EB772BB8B51EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8F0081C0EB913B4A12C9BA7F9E2C44CA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>CombineLatest+arity.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/CombineLatest+arity.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8F5E62777148745FAFCD9848F2216462</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A47B3D1B773D68299EDABB9A4D54E96</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8F6F72CD5B62C5C3465BA5E974A333C1</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>383E8395E05602750FB92C87A2FDEB92</string>
-				<string>B938000B6A988DBB740EE2ED9F411571</string>
-				<string>B9D561015C9DD423C4695CE8F7CAE062</string>
-				<string>8FC936CA127BE8A8C9DE8621E29025C9</string>
-				<string>7980E42EC0632C1655018D3F9FF4FF00</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Classes</string>
-			<key>path</key>
-			<string>Classes</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8F7CCA301B616F7D8D91666A274C9185</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa</string>
-			<key>target</key>
-			<string>614365A9E4840470AC452C75DD2858EC</string>
-			<key>targetProxy</key>
-			<string>A189BB98A9127C953E6B4A32A68E859F</string>
-		</dict>
-		<key>8F88D395752826616234A8383CBDCA3D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxCollectionViewDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8FB5D2484879C5E0D0AC211D9FC603D5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>CombineLatest.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/CombineLatest.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8FC936CA127BE8A8C9DE8621E29025C9</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>7F9DCD3DE6178587C27AF8D985383E08</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>path</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8FE9F9B1EC3C5A7D2D6CDAA2C4BA9BAE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>880EC46B2EA4171F124091B6A8EEC9BE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90379C4D111C3BB8834CC117AD072DE2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E34A5CB470BDF4610D116B4C6E6310CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90F97FBA1E50C1F43EAF8F3FAABD06AB</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RxSwift.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>90FC859F6BEF7CA9F25A3F57BEF925A5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B746BEBFCD9CFA793E10E15D5E7B47D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>91721397EC011682D479904C93C12753</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7D5E833F61266E85C52B9AFA5BDA55F0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>920C57CA223DED99EA2B9BF7416E8664</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Amb.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Amb.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>922DA1B8B35C278C5E7E06E5EC5D9D74</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2F12CA77D6F2C4B36E0E751A89004250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92A2FEAAF18E42ADF6CC190BFA27217D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DD670E6BA419147639CA62FC8C3CEDA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>932A608D68C76DBCD3887C0428352870</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B5B69664E4718AC7434121C115138625</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>935D94469ED0B54EACC3A4C0F12B4646</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxCollectionViewDataSourceType.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Protocols/RxCollectionViewDataSourceType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>937967AE1F14874EF338B1B8F57AA23B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UITabBarItem+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UITabBarItem+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>93CBC8B4B0B4A92CC028405BADDC7BB7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1B3B751B0C5F626CB6E8FCE543FF5CF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>93F4DB97B25A1296A903B4E94A63FB61</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>94253F9E40DD9BBE9F3C9329447B4968</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8FB5D2484879C5E0D0AC211D9FC603D5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>94E8B074971AF38C0412AE173DB4552D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>9505DB71A910A7EA4A2BC2F348605F5A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2F12CA77D6F2C4B36E0E751A89004250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>955FA3AF691A7749E601D60274BF0519</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>CA139E952DF537781D766699B18CF101</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>95792EE983BD8CEAA248950D147179F7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSControl+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/OSX/NSControl+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9594E7B489E20FA0CE16209AA0D9A33B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D0E9E99E1790D8207298D944DDA5D4A2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>969EF9A054D7A4FF9D52EC47F03E29BB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>974A7B9743248803127142B96776A1CF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FB5C6A9BAE45FFA2C75DC00EC9F9430F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>976CED50E8A41F564ABC9D9722A9B749</key>
-		<dict>
-			<key>fileRef</key>
-			<string>94E8B074971AF38C0412AE173DB4552D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9786556AA0483D04DD189DA66A8BB80C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90F97FBA1E50C1F43EAF8F3FAABD06AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>97C61F2EABC0E0556306C355CAF9A9DF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FD1A57E1C3EFB8080B64032CEBA6EEBA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>97E089F34EA8E281F450990124ADE867</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>99275884D21412F97109A8169AAC77F4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8A2FE6EDBAF67DE1651CFA7C30C0FA9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>99B67115B280334F9D6E4561C6A2B9B1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C862CF3BD7290855D8AD7565CD8E2666</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>99BCD2A0F6991CED214B3FE26A22B907</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>613CFDD9885D7CC54BC0041A8B2E9FE8</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxGesture</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>9A2B0DA384E6A125B6430754BD9E8241</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UISegmentedControl+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UISegmentedControl+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9A67BEAAD395C1FAB9421B85C177D655</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3804ADE6554A61F56E0FCD797E6D3084</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9A72425633B1074724BE4AD9E253486F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>72A3310CDED6F0B1AC6B42A981CC578B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9ADA5122804C363890866E9689DC09EB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>19E010F7B88BB02E629463A73BA403E1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9B0124864FA21CEC6CC3F9B3C55B6F65</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>FF12F2A0C3DB5BC71502F2741134C221</string>
-			<key>buildPhases</key>
-			<array>
-				<string>14F184D4578891EF5AF48A72242696D6</string>
-				<string>195A0BC9DB44EB9697A3A61170725E9E</string>
-				<string>EF3D61D08F8C97E0BBC4BB5E0115CC6C</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>847834D1DB009F49A71F9BE5F785B24B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa</string>
-			<key>productReference</key>
-			<string>1F19AA9E3785650C8EB42205C1EC4C29</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>9B27914C2D65E7BCA3CAB1D2365E645D</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>C87E6CC572B39715080A5C3C3D52AA7F</string>
-			<key>buildPhases</key>
-			<array>
-				<string>D6DF8079D60BBBC0561EE11B941804DC</string>
-				<string>EFC5A0F424A48800CFC4B62F20F6A218</string>
-				<string>205B1218645F50D5705293C3858B0490</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift</string>
-			<key>productReference</key>
-			<string>638D81BBC0A578B83C471D806B095768</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>9B35043F7EA722855C342069EA69F80C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FC278E77933E0D1F364DBD2B0A24180</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9B45A1851F5175F17D0F160D545D2D22</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>FF39F572578F134BF8414A8D27FD3729</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture</string>
-		</dict>
-		<key>9B6B4A1F1ED7FC887699E49A2A6262A4</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>9B0124864FA21CEC6CC3F9B3C55B6F65</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa</string>
-		</dict>
-		<key>9B9B0018B167196825E5FC64DF2C60D9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>714C5305FFAFC2F0793D969801E49179</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C03589B9228FF4EBFA9A3F7C7453EBC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>10EAC6560D0E865FC286D0B2CEB21F8D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C6B788D60B66AC712BFEF712D9BE4B2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIApplication+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIApplication+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C6F3D50FF5622B23E76113A13182DB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B5B69664E4718AC7434121C115138625</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9CA8E982B83600D9910D7D70B286823B</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture</string>
-			<key>target</key>
-			<string>FEC7E09BE7C35F9F8658D953E429D451</string>
-			<key>targetProxy</key>
-			<string>EC09866E2A98A4329F1656536A729543</string>
-		</dict>
-		<key>9CE5313DC68E5A2FFE47DB9B6FC673E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>KVOObservable.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/Implementations/KVOObservable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D04517DD6AD2781E4CB927E673828D5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Zip+CollectionType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Zip+CollectionType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D33872BAF4DC5FEC16683ED5494A07A</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>20618F75B2A8404B53E0916FE475229B</string>
-				<string>2E8AE45009EAF83A18B9DF5D362ACDDD</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>9D76728BF899DC869752E1AEF92F2522</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Cocoa.framework</string>
-			<key>path</key>
-			<string>Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>9DD6A6C23C63D4EB73064E6C68E20CD5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+StandardSequenceOperators.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+StandardSequenceOperators.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9DDCA6731F75967C99C394CD687BA328</key>
-		<dict>
-			<key>fileRef</key>
-			<string>477AECB674F89335ACC974874BAC99FC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9EBAC0789FA5CD3B9A97859B6633DD22</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Buffer.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Buffer.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9EC42C15F58BCE37BC88E12D6733EF4B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EDBB3142C058BFF8F0B79E20C43D86F8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9EEA1B9C1EA4C125354E33390B6E85E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9EFC8B35852B90A6EC3A9D47486CA105</key>
-		<dict>
-			<key>fileRef</key>
-			<string>935D94469ED0B54EACC3A4C0F12B4646</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9F217F9C4E260A51EC69B826D1ECAD47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>02736A0824ED21A5F170A055AAC18B5E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9F22B19D087C06C030D8F2540356AA99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D9688474E44B841F6129B4FAFFB2C565</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9FE76B6763DDF6DDE5A227F3FAE42324</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7CD8DFA3BDA378BDC5FF885379349130</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A03494739582FEBB17DA79D2920E1F7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>032DD707905DA8D3C57277EF878F3240</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A07E4C0953ACB36A5DA675ABEDA61BB8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D9CDE42D609590B6AA8AAD038BF20E21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A0F6D25550D0AB1122728E0E202E9B2F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2EA5E789256C909EFAB76C6238E9F905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A0F993C4C6D6C90DB6204A41E10A910E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A138EAA2EF4367C0E438246F137F7FF8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F90193FA637C5E3C76DCF1888950DB2C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A1435F6083BF431922428FD10EC7A363</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49FBEB4800AA72C5B24F339E2CE4492A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A1558AC0EC6057A3B2E5C0A902FC1623</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3804ADE6554A61F56E0FCD797E6D3084</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A16B90AA9D152514C8ADF7451C1E90A4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Generate.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Generate.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A189BB98A9127C953E6B4A32A68E859F</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>614365A9E4840470AC452C75DD2858EC</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa</string>
-		</dict>
-		<key>A23025D7CBEA011BDDB9A5ECF666C1E8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SubscribeOn.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/SubscribeOn.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A251D2B4AEC83C9A367126EC5FBD3154</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8BF27BBCB2AAD5C679581C38EE2DC185</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A36FEB7BB3E2CD50B80A49D235925AF3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa.modulemap</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A3B83162A671B863092C509640455BB1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ToArray.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ToArray.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A411B27CFFCA6B4EA5F4A46033C005A5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B594A1B0AF0D78EE827EB80F48CFEDDA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A486D9E086D5087509C0FA917C16E181</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A4FE2267F0D28CB4EDFF93E2BEA9E8B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C7E745319BCA81A3F171ED2C1DF23643</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A54A1ECD706A5EA99BE7D81EAA32A26F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>867FB6D9CD5ADD06727AA1E89197078D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A5867CFCE263A489500E497E982C98B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C63811859DE646A04ED30107BC30950A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A58ACD233E056D2610BCF047FC636DD1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F5079F022D850EE97985FE670AE654D3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A653AC721AB76BD247BD21ACB54FC4E1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>26AAE4981F2B2A0B345D49C6FFF3F191</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A6985271C67D3D39671F6594CC636975</key>
-		<dict>
-			<key>fileRef</key>
-			<string>59638383E4045E9D58DD49A2FAD59AB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A741711B1571F9AEDC76DF57CDCC049D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D12DB9FC05ECEBD079763E18E22438A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A7485BC75D5D55862531507EA811F6BA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UISlider+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UISlider+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A7C8FF6E8BCA336FC4D4600B633328D2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture.modulemap</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A7F78203B95EAC361DD6C18C24D9C6EA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A16B90AA9D152514C8ADF7451C1E90A4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A80F223FA8DE3EFF2B59F5356E114EBD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>236983DA69E6A12F58775605239117DE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A870750758D17331ABB8C0A6FBEE9183</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B26A5D41DBB998BC91E988B0B68FFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A8B8C84A3664BFD488DDAC8393D52116</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa</string>
-			<key>target</key>
-			<string>614365A9E4840470AC452C75DD2858EC</string>
-			<key>targetProxy</key>
-			<string>BAE5E5AF1B14DE4D1BBFC3E9FBBF1FC2</string>
-		</dict>
-		<key>A8D37F4EA054BE484E3BB6DC1A471493</key>
-		<dict>
-			<key>fileRef</key>
-			<string>754393E014D5DDCFD533E33A02544594</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A9446ADAA8A85A0CD4223AB8788DC5B6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A995AACF502C4037D6FBC4C6112ED3BB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Sample.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Sample.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A9BF5397CE64E09EB5C37D737FA40398</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RecursiveScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/RecursiveScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AA16F216C37B4D26B2AEBA5318F20F2B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E592BE42F6C322EF48759A3D652B83BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AA5369D0171DDDBBE6116FCB66834C5D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D2AD1791E2917EF6FCE255F4894FA8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AB11A18FBAC250B26EE7C7A08E3B8813</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06E8FE7D88F5AF65F3E6D57C39B12F30</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ABB75716FC955FDA06FCD29DE6F32178</key>
-		<dict>
-			<key>fileRef</key>
-			<string>37B0B8B080F1E6B923BEFBBF2DC5B11C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC00F08A8CDC8D49C2A4DF634C4AA16E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C87E53818AF138ACF5D61B3D7D6E5274</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC31759D90FFBB778349105CD32B82A0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>TailRecursiveSink.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observers/TailRecursiveSink.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC8E5C01404D499F26CD4C999E341E12</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3A8C262F7B62C28B263F49AACFDFAB2D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACA5B0347B999FA572ABFFE737CA7AE5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>94E8B074971AF38C0412AE173DB4552D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACDB236E3E70B35781D525D0318E5BB7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Extensions.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observable+Extensions.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AD4ED07FD9EA0B454D9798F141F5CE97</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3923CF81B57F0AB60F4DE73C980321DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AD57AA83FCA2E0F8E94E8CAFC455341C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxCollectionViewReactiveArrayDataSource.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ADC23C0C5CA9D89EC7970AEA31E22133</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0905B95004BC92DB93247A62B00B3165</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ADD429CB6F5F9DE75256086A939119B1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0522CD8F0D5EA4DD356A6C34B68879AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AE2DE95184E55408F0BFC4D170AF4C04</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>StartWith.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/StartWith.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AE5FA788DE0D4E7D6D60BA1CEDEEFB62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>37B0B8B080F1E6B923BEFBBF2DC5B11C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AEDB7B436E22D693CB5360DB88CE7450</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UILabel+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UILabel+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AF308452C9E3E4F62252D19FBD918CA7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FE1DCEC4B3D1DAFFC879A8BAB2E0B13C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AF73F748061BE56ED8FDF3F99D0C0803</key>
-		<dict>
-			<key>fileRef</key>
-			<string>79EEA13950D3C7E26EA2C570F80B66C2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AF895FF485271D550E4D064A84FB2619</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C686CEFDB56AF5DFB18118006274FA02</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AFE010FEC036F74911E6F9609402C03F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B0105A3A5AF33D1CF3973AD0CF4AEB9C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>InvocableScheduledItem.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/Internal/InvocableScheduledItem.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B03014AE13A5E078B02A052A0FBE9A20</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8806CC77B1040592A24B4F57B756C9AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B073BB08B89B47C6FAC0A2BC30BEB5EC</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>AFE010FEC036F74911E6F9609402C03F</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxCocoa</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SWIFT_OPTIMIZATION_LEVEL</key>
-				<string>-Onone</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>B0A9FD2263DA835993FD907E4B4CE2C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D9688474E44B841F6129B4FAFFB2C565</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B22467B22BE2003C76E33AAA9CA35DE3</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9D76728BF899DC869752E1AEF92F2522</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>OS X</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B30D924AB6FBA8B2DCAC4FC1495CB45F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4DCA1F1EC467C456DE2F6B57B5C35A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B32070E942F1B441075C288B6D0ED075</key>
-		<dict>
-			<key>fileRef</key>
-			<string>54133C9D54D6BD5ED81DAE23B47861CA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B3A94B8B6CFF3BB21B54E37E9A3CC829</key>
-		<dict>
-			<key>fileRef</key>
-			<string>33A5CCFF7C755C16BD3B5DB4FFE1F88D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B3DB15563E7138CDB04ED4FEE30F9C0B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>15B5E4C3EFE2725A54E98104C2781351</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B54EEB7F3D9B9D4D2E5708405A57F65E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>TakeUntil.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/TakeUntil.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B594A1B0AF0D78EE827EB80F48CFEDDA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SchedulerType.swift</string>
-			<key>path</key>
-			<string>RxSwift/SchedulerType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B5B69664E4718AC7434121C115138625</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Aggregate.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Aggregate.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B5E007C19DC437B74F3B459606D3B040</key>
-		<dict>
-			<key>fileRef</key>
-			<string>65D1EB659125EA3969D59014B9F4E1A4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B636038A1B7E8207534A0915F7BDD838</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2F12CA77D6F2C4B36E0E751A89004250</string>
-				<string>90F97FBA1E50C1F43EAF8F3FAABD06AB</string>
-				<string>ACA5B0347B999FA572ABFFE737CA7AE5</string>
-				<string>B22467B22BE2003C76E33AAA9CA35DE3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B6DFC690E7D0B1E5CADCFC3D7483685E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>66A938D2640AAB94C102006232D3177B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B70DB572A950F95B2749F85F2D2A4F31</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>74EBCCB5B3263EDA7A8F3F071712CAFD</string>
-				<string>2AD0AB82C8DCDE62D31342BBA1A5AB70</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B746BEBFCD9CFA793E10E15D5E7B47D4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Just.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Just.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B77B250A5C4091D9437711ACFFE1A60B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6E477EE3500BD6A016CE1951B989CF75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B8393E60BACCB4386FBDC6A62A9FA561</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B8A2FE6EDBAF67DE1651CFA7C30C0FA9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>StableCompositeDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/StableCompositeDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B8B9F1EB2BCB1B79E946A0A557D77AB1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>637B39D283F2B3C1CE39F900E3526F2C</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/../Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxSwift</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>B8E890AC72A2B515423B0873EBA7497B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>60F618BDF7BC2AC6CC2A49F4069E5944</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B8FD0CAA10337CBD9FC73B16905717B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FA173D102727E0176EED982ADA11269</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B938000B6A988DBB740EE2ED9F411571</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>RotateConfig.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B93E360837BF6049E6ADBCB496DD486E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>449F0019DD1F3E76574EB8C06356C328</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B94D6C7DD2DDCFDF47973632D61DB036</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Multiple.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Multiple.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B9D561015C9DD423C4695CE8F7CAE062</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>path</key>
-			<string>RxGesture.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>BA8B75DCD8B33C4AD231FA051BF3EFC7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>777BF9DD554FFC95F2DFA576184620D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BAE5E5AF1B14DE4D1BBFC3E9FBBF1FC2</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>614365A9E4840470AC452C75DD2858EC</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa</string>
-		</dict>
-		<key>BAF807493CB41AC83E6E5BF2D65CA107</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BFFB4F5995EE9165EFF01A1B67E31329</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB34D4B1C2FA534E510E5A6F93EC78C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8393E60BACCB4386FBDC6A62A9FA561</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>BC0F59D8DF7183BCA7D0C4C53E1BC98D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift</string>
-			<key>target</key>
-			<string>9B27914C2D65E7BCA3CAB1D2365E645D</string>
-			<key>targetProxy</key>
-			<string>E19FE5C08FA3F61711C410D13B756BA0</string>
-		</dict>
-		<key>BC48F2F74FDE1124DE6CA9C516A65F1E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90F97FBA1E50C1F43EAF8F3FAABD06AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BC5384AAA357E269F58CCF248EF00C45</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>_RX.h</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RX.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BC6C0360F2323A799BCA9C0911695482</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa</string>
-			<key>target</key>
-			<string>9B0124864FA21CEC6CC3F9B3C55B6F65</string>
-			<key>targetProxy</key>
-			<string>D191CE7C858A07E1680413AC79142656</string>
-		</dict>
-		<key>BC99BB8FACD40E788CCAA7BDFBC77498</key>
-		<dict>
-			<key>fileRef</key>
-			<string>40731FA149D0C969EF2ACC2B814AAA39</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BCC627EFA42BCBDD8FC0B3721D139E61</key>
-		<dict>
-			<key>fileRef</key>
-			<string>79EEA13950D3C7E26EA2C570F80B66C2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BCDAA38E7E8D4116EA76D257BC319C4D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>283198B3A1BC9C9C64AF8776DF9D8602</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BD2F6DF7E83A8F2FC1A44E6FED0C1B6A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>8A01F5D8032F07A5A0D80DCEA17D7282</string>
-				<string>14E592CECFBE338044522B24E1481FE6</string>
-				<string>7783C8B43B0F83A3E122DF1748EC8CAB</string>
-				<string>1C2DB5C4B575F0B74C596E23A59C934A</string>
-				<string>8526D54EBF04F2654F48E763F88A8142</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BD376A3A84020AEE9C9152B28EC0E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1E30F06ECF68CB0C48EA50C7EE7B2433</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BD94DC753DE37948A6725AFEB246FC78</key>
-		<dict>
-			<key>fileRef</key>
-			<string>32DB01547F7219DFA5AFF3C2A27DC685</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BDDF748143E479CF6EABE05041F7B6F2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A23025D7CBEA011BDDB9A5ECF666C1E8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BEE7FA81B3281D16D65348F06A05E393</key>
-		<dict>
-			<key>fileRef</key>
-			<string>94E8B074971AF38C0412AE173DB4552D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BEF4A476C5C6C876B27C5F88A81B5043</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E34A5CB470BDF4610D116B4C6E6310CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BF180276153CFFF40164206E6A3BEDFE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6399E931BEE7F5E5F5E04BAA0FC0DE34</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BF46C30F6DA5B7E88423642828CEEDF3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8E3CECCCF5890CBE65780B3C8D44E2B1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BFA9612F9925AA3168C6A101B4C99CEF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UITableView+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UITableView+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BFC2B5254C88254A58C95900FBA83AA3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3871A7C8372F1322E306860D1430882B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BFCDB1F0CB2317AA6C5C494CE54FE8AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73E7917F369F21F0188070F597CDE8E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BFFB4F5995EE9165EFF01A1B67E31329</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AnonymousObserver.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observers/AnonymousObserver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C04B8E1CB28327C6E3329D5C505F1E5F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D9F0A2FEE585A9018680D5769208A755</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C0A6FE769DB8A583B4AB4F853DCACCB8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FC278E77933E0D1F364DBD2B0A24180</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C25308CFE7CECE3CF7E9AC0EBBD33AF9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Catch.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Catch.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C2C7F0554D20A58F6D5E3657640E6745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E058D4EBE0ECDD108B8578F0C62D285A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C317D014A7DBD70F5AB21D95B1C1DE85</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DFDC7869C929289A9CD3A92B63C692D1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C381F6C0D2BF123EA57219C3E98C84C4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift</string>
-			<key>target</key>
-			<string>D7D2E8A3E11B6A93694AEE6F34218DD3</string>
-			<key>targetProxy</key>
-			<string>3B18CE2FF2F45E60306F01D5887056D3</string>
-		</dict>
-		<key>C3923EA7357FC6223BC856AAE0F07580</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ImmediateScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/ImmediateScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C3A0C86A2E540C585BD9EED8227FC082</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SkipUntil.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/SkipUntil.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C4122641759BCB149F3FCADD5C3268F7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Error.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Error.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C4C47BAFEE1709C11AB5145DCF02D960</key>
-		<dict>
-			<key>fileRef</key>
-			<string>65C5DCE08601B273DE0CF84D2AC1CA7D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C4C8C36FB51CB1A5BEED5AAF41603DE2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9D76728BF899DC869752E1AEF92F2522</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C4E0857D9EDB53394B79170F060B50DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CF5F9B539C916CEB13C073BD9B8706C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C63811859DE646A04ED30107BC30950A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Multicast.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Multicast.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C64491ABA744A4BD99C4CB1D733B5DA3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxMutableBox.swift</string>
-			<key>path</key>
-			<string>RxSwift/RxMutableBox.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C686CEFDB56AF5DFB18118006274FA02</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>TakeLast.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/TakeLast.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C6913A7E9C0C2474F28A914401538F1E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>419FD89DFCF42A6ADFE86D2D84B0EA46</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C6B15BFB809D0286742C1447591A61D9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACDB236E3E70B35781D525D0318E5BB7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C7173C062C939B53E256CEE89C8C85FA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DA208E4396D571B3FF2C758E089F3C95</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C72E3C80BC9C48E5640A4CCEF40949A5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DA208E4396D571B3FF2C758E089F3C95</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C7A741BE56BF66F4F2242CF3B34F1E6D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ScheduledItemType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/Internal/ScheduledItemType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C7E745319BCA81A3F171ED2C1DF23643</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Zip.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Zip.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C81E9FE86F69EE1D3FAF2AC827103164</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2E17907AF176E8F017DBA35163551D37</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C862CF3BD7290855D8AD7565CD8E2666</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Errors.swift</string>
-			<key>path</key>
-			<string>RxSwift/Errors.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C87E53818AF138ACF5D61B3D7D6E5274</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Skip.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Skip.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C87E6CC572B39715080A5C3C3D52AA7F</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>7F089E4EA414B734ED9F56F71D01F01E</string>
-				<string>7BBDD3EDB691FC01479A70C69E47CEE7</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>C920A009DD877D098FB578E0E50EBFD6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CA139E952DF537781D766699B18CF101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>94E8B074971AF38C0412AE173DB4552D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CA440FABEECC06934002C5B7DFFD96C3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>BehaviorSubject.swift</string>
-			<key>path</key>
-			<string>RxSwift/Subjects/BehaviorSubject.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CA682272C2916EFCE819012AA8F6F4C6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>PublishSubject.swift</string>
-			<key>path</key>
-			<string>RxSwift/Subjects/PublishSubject.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CA7750E5ABEF5F2B68D50415B80A5EC9</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>9B27914C2D65E7BCA3CAB1D2365E645D</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift</string>
-		</dict>
-		<key>CAAFF37D2CE77D76494B7F42ABF4792A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Rx.swift</string>
-			<key>path</key>
-			<string>RxSwift/Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CAC81FC6ADF84CBF9D24DF18F08820B7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AnonymousDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/AnonymousDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CADA73E1D18C4B1507FA15CE4A973324</key>
-		<dict>
-			<key>fileRef</key>
-			<string>72A3310CDED6F0B1AC6B42A981CC578B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CB32E46DA8057A3A622F29F4500772A2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Scan.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Scan.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CB48DAD7D5163991153C05BD30040B6D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>_RXObjCRuntime.h</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RXObjCRuntime.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CB761ED25DD8E01E6FE70D51365524DB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D1541DD57D56EB09CEF071E8D1144E48</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>CBA8DBF45CDA4CFC978E23AB26A807E8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>95792EE983BD8CEAA248950D147179F7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CCE36FB9BC39FC2DA56F7ADB0C6B04D5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>036645378416B45CDB8CE10B07BE2213</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CCFDBBFF08F74F9511DF21F873EABE86</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSObject+Rx+RawRepresentable.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/NSObject+Rx+RawRepresentable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CD4013CD18B320C79647E2D4EA37E582</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.10</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>${SRCROOT}/../build</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>CD7301609168DEDFC3736C07BA0881B1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6E0C7DD780E181D0F5EB28D77EDB199C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CDBD80EB63A3482BF30B876938782D2C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>680753ED29B2B36844E7BF1D3EC725DE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CDF9FEDEA4D51C517D572E46FBC8621C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B94D6C7DD2DDCFDF47973632D61DB036</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CE245DA8E68C8D112CEF7E56A751CD90</key>
-		<dict>
-			<key>fileRef</key>
-			<string>920C57CA223DED99EA2B9BF7416E8664</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CE528D85B9B645900D89164F2722CFF0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CAC81FC6ADF84CBF9D24DF18F08820B7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CF029F863E85E7C03591D4210989B647</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2488AC35E99BBB5538B1BD95F7655E94</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CF5F9B539C916CEB13C073BD9B8706C9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIBindingObserver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/UIBindingObserver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CFCF19080BB274D8EEF1B5A844B36F5E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>26F86A42574378E3C19BB20A1D4F6EE1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D06B278E015398E2A3B9AB600AD200F1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D0E9E99E1790D8207298D944DDA5D4A2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>VirtualTimeScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/VirtualTimeScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D12DB9FC05ECEBD079763E18E22438A0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DelegateProxyType.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/DelegateProxyType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D13E9BB839200D5CD261004AF41268D7</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture</string>
-			<key>target</key>
-			<string>FF39F572578F134BF8414A8D27FD3729</string>
-			<key>targetProxy</key>
-			<string>9B45A1851F5175F17D0F160D545D2D22</string>
-		</dict>
-		<key>D14C2BC5CCDB880C6B15F4858C458EB1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4B20F6146FF7DCA5A308859C677FAA81</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D1541DD57D56EB09CEF071E8D1144E48</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D191CE7C858A07E1680413AC79142656</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>9B0124864FA21CEC6CC3F9B3C55B6F65</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa</string>
-		</dict>
-		<key>D1F1D0390E73502FE5C22246171BE72B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3ADD86DB658ADA7B22F4A9E9D1DA25A8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D1FE0E16B1F05DFE7771055D52939287</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3426C8436E0E44F1E70A1F7BC6D4BF63</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D20BEAC539F3FDAE5D9C0E1DD60CD4C4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>634F4ECE00431123C06FD52C27501C64</string>
-				<string>8ABCA9D25D5ED7D25B873051B0E2BAB5</string>
-				<string>A7C8FF6E8BCA336FC4D4600B633328D2</string>
-				<string>613CFDD9885D7CC54BC0041A8B2E9FE8</string>
-				<string>12B7233B7F267BF399EEED6714BCE42D</string>
-				<string>D06B278E015398E2A3B9AB600AD200F1</string>
-				<string>FD1A57E1C3EFB8080B64032CEBA6EEBA</string>
-				<string>4BE2E8575BDC4E03E951EAE8E023EA7B</string>
-				<string>82A721AFC5D1B757D919FEC84F9FEF74</string>
-				<string>6125CFE9D1577552DB75431F0817A868</string>
-				<string>C920A009DD877D098FB578E0E50EBFD6</string>
-				<string>F7C711FE0E199D267B5A4E427D1FF097</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Example/Pods/Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D2AD1791E2917EF6FCE255F4894FA8AD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObservableType.swift</string>
-			<key>path</key>
-			<string>RxSwift/ObservableType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D2CB38767A2E8CD22E0C3F424ACDC178</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0AC1F877E92090E34F5CE2FB79F4629D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D368C07F4793B141BBE46A5B8453B177</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObserverBase.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observers/ObserverBase.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D3F77243EF52EC5DD00A359FD77D68F2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>AE5FA788DE0D4E7D6D60BA1CEDEEFB62</string>
-				<string>CE245DA8E68C8D112CEF7E56A751CD90</string>
-				<string>CE528D85B9B645900D89164F2722CFF0</string>
-				<string>AB11A18FBAC250B26EE7C7A08E3B8813</string>
-				<string>C317D014A7DBD70F5AB21D95B1C1DE85</string>
-				<string>077B2088D0B86F82BDEBA1EBFAE9669A</string>
-				<string>7434BE3361F7A52BAE1FC831D881C933</string>
-				<string>DA600661558FFEB04BB1DA6E56D7BA9A</string>
-				<string>659676DA59F72833BBCCB9853A143C7E</string>
-				<string>4A6886197AD7FBF1B3FE9A919B412C2A</string>
-				<string>6956E7A76E55AB0986EE76E8CDF2AC47</string>
-				<string>71BC036D660D42931AC03ABF46519321</string>
-				<string>DF644BC19728B14C164A989F9C370CDC</string>
-				<string>D56B102D752D618E23E784BAC7AFAA95</string>
-				<string>70E1CCCB0F08BF258F53C425F111D784</string>
-				<string>3EE7A1AD2ACB8E5B50341976B1316CAB</string>
-				<string>68FDD0E090F8DA37A3283ABA5E5DEF50</string>
-				<string>55FD4EC3DFD48707D686FB0E30E9CFEB</string>
-				<string>BCC627EFA42BCBDD8FC0B3721D139E61</string>
-				<string>C04B8E1CB28327C6E3329D5C505F1E5F</string>
-				<string>6FC7A3AACED3A13E19B113FBFFE5F6A6</string>
-				<string>F150F627FA22644A5A75B5B046FF3B6B</string>
-				<string>9C03589B9228FF4EBFA9A3F7C7453EBC</string>
-				<string>87106C3E8834791259A7E930EF519CD2</string>
-				<string>D6B1F7F217F77E9186E76925C6CE6D3E</string>
-				<string>750B5432B0FF3138009F3EEA57AFE84E</string>
-				<string>E49783BB78FFE662360F74DB16C026FC</string>
-				<string>6982B8E4C6FF27973BC4186FA1B03D23</string>
-				<string>FD3053D58B4B90A6385906722E65D5E5</string>
-				<string>14F0CB6A70A3D96F1C4BE2E5CCF9C2C4</string>
-				<string>758C1D78FBE53E84387DB6ADD0076CEF</string>
-				<string>593F579D1BAF6BE32C0C8EE70F88A84B</string>
-				<string>57441D145F1BBDF326D2F35A2E722FEA</string>
-				<string>9F217F9C4E260A51EC69B826D1ECAD47</string>
-				<string>9B35043F7EA722855C342069EA69F80C</string>
-				<string>FD62880460C77E0A9BAF5FCF3EB7E4CA</string>
-				<string>5CD5BCA415EF28EF307CECBA0621EAC6</string>
-				<string>99B67115B280334F9D6E4561C6A2B9B1</string>
-				<string>83E43C0E90CB742D1536BB8DA28FC055</string>
-				<string>1F76BDB26F35646A511521BFC163D808</string>
-				<string>F7D7F0E69267A2EC33065AC12526C089</string>
-				<string>7A6AB5F92240D1411B8C16AA3601EC2D</string>
-				<string>FC726DC55B0CC8247FECC7370424A3AE</string>
-				<string>4532A8C74BD6D971D4ABCC991604D0B7</string>
-				<string>E4F716E7B90B006A0A58F63CC6266D4D</string>
-				<string>4FD268B8698165B5E6A0F33480CBBC33</string>
-				<string>4E0B27C110E6EBE3540BC9CDE16DAEBD</string>
-				<string>F61BF2C739E958D5E5D08C55E5EAF0F8</string>
-				<string>90FC859F6BEF7CA9F25A3F57BEF925A5</string>
-				<string>27319C465E633116B267CA247084A624</string>
-				<string>6CAB49D89624A04E4152A06D8E5AC124</string>
-				<string>B3A94B8B6CFF3BB21B54E37E9A3CC829</string>
-				<string>09DE898823F74CB06BE5792F0CC7D1B6</string>
-				<string>5B3561537F5610E105E39CD7552E1426</string>
-				<string>05C4DDCFD41B0362192795C66D54E2D4</string>
-				<string>9B9B0018B167196825E5FC64DF2C60D9</string>
-				<string>E72B0C0D6CBD12E8A5F21B72CDDD7203</string>
-				<string>93CBC8B4B0B4A92CC028405BADDC7BB7</string>
-				<string>9C6F3D50FF5622B23E76113A13182DB2</string>
-				<string>3C7AC628FB1EABCBB60604EF5F9E9DDB</string>
-				<string>74B6F38577B25B297F2010325DC77DD3</string>
-				<string>100E0FBCFBCB8BE4FEBE0CC293730203</string>
-				<string>32CC0E764B6FDD289813E6A11F422622</string>
-				<string>C6B15BFB809D0286742C1447591A61D9</string>
-				<string>CDF9FEDEA4D51C517D572E46FBC8621C</string>
-				<string>6744289BF897F4D0525E1819B31C7CA9</string>
-				<string>56FD49EF04E53934E3A49F07237ACAE7</string>
-				<string>B03014AE13A5E078B02A052A0FBE9A20</string>
-				<string>C72E3C80BC9C48E5640A4CCEF40949A5</string>
-				<string>A54A1ECD706A5EA99BE7D81EAA32A26F</string>
-				<string>AA5369D0171DDDBBE6116FCB66834C5D</string>
-				<string>8E9D487DFEA8015CA9E7123698C10196</string>
-				<string>9F22B19D087C06C030D8F2540356AA99</string>
-				<string>270525BB31443A4DDFBC264C35F83AA2</string>
-				<string>2E4A651B3831DC039C0967839B8DE460</string>
-				<string>DAC73301778EBDD3A376AB81B1706375</string>
-				<string>51C2DEE2E38271654A307DB0A57826FB</string>
-				<string>92A2FEAAF18E42ADF6CC190BFA27217D</string>
-				<string>1514F07E372FBDC4AC1D948329D062B3</string>
-				<string>67CAC0F262FD2A9FCA59C6463798FCAF</string>
-				<string>B5E007C19DC437B74F3B459606D3B040</string>
-				<string>4BCCA5EA84D6D228F84102A8C62BC93A</string>
-				<string>58F145B976F3F9425E87313ECFD8E02E</string>
-				<string>E3E5A164068D5B2AAA03B81990810232</string>
-				<string>6D2AD61B12BFF5101ACA654F7586EFBD</string>
-				<string>D1FE0E16B1F05DFE7771055D52939287</string>
-				<string>974A7B9743248803127142B96776A1CF</string>
-				<string>A80F223FA8DE3EFF2B59F5356E114EBD</string>
-				<string>2548DC0992B55BE1E01A3957E8DD6D31</string>
-				<string>74F5E7BE653FC92CDD229EC32CBCDFE9</string>
-				<string>2F4CB61EB466CCEAFBC662A76FE12D81</string>
-				<string>53C9EC191E217693F417F3F3D5BD7E43</string>
-				<string>065D3BEF76FFE3B3DF7B72302D5D7DB0</string>
-				<string>7418514157E5C688CE763A5F254CF413</string>
-				<string>D7500103A9FAA223279359D5F701B1CA</string>
-				<string>18F6CBEA55853D5400671FFC872FEB8D</string>
-				<string>C6913A7E9C0C2474F28A914401538F1E</string>
-				<string>09B3B057734A3D96C3EFDEA6F6098411</string>
-				<string>8E2DE5024F9792C19792D92B8B1D985D</string>
-				<string>88FC4A07660873918F076FF438E24176</string>
-				<string>8987DC4DFACCA1F78A94D60F1EDFC99B</string>
-				<string>0CFA33E64D14743BE85F0223890703FF</string>
-				<string>CD7301609168DEDFC3736C07BA0881B1</string>
-				<string>47C71957DC7BADC013C58987277C1BD2</string>
-				<string>DEBACD931A5946D126B0215F2E5490E9</string>
-				<string>F17C36EE5E47C26D58ACC1C16C169A83</string>
-				<string>F42EBA332695D4D99D6D6AE0531E8476</string>
-				<string>420B2B089843D05295392FFE1944FFC5</string>
-				<string>01803CDE548981116E7A943E1E109A39</string>
-				<string>D5F0C6BCB89A7D95ADDDBE8D79996573</string>
-				<string>2E0F6361F3899645D43F388A5C267D4C</string>
-				<string>99275884D21412F97109A8169AAC77F4</string>
-				<string>242CF41A195F0BFA5D26BA5901A077EA</string>
-				<string>55FD53BACDCF756892618AE87B40E110</string>
-				<string>48FDC28F367EE164320F7C40A5BBEF6A</string>
-				<string>BDDF748143E479CF6EABE05041F7B6F2</string>
-				<string>FF2C60939A60815A9D77688C30A55CE9</string>
-				<string>A870750758D17331ABB8C0A6FBEE9183</string>
-				<string>815412E715BE08871E4C5ABC97006596</string>
-				<string>D1F1D0390E73502FE5C22246171BE72B</string>
-				<string>566759A64E3D6143035478A562348AB4</string>
-				<string>0E6188767C3FAF3698E2230366164E66</string>
-				<string>3E2ECDFC62B33F044E1AF48EB320DAE1</string>
-				<string>A03494739582FEBB17DA79D2920E1F7A</string>
-				<string>F16FBB4B6EC68C9609A904B8BE63BA36</string>
-				<string>7908C1A8D99504533AC23866832E9706</string>
-				<string>A07E4C0953ACB36A5DA675ABEDA61BB8</string>
-				<string>8FE9F9B1EC3C5A7D2D6CDAA2C4BA9BAE</string>
-				<string>B6DFC690E7D0B1E5CADCFC3D7483685E</string>
-				<string>F9EA78A1A667DF3843D7E1F2D6630F38</string>
-				<string>E4DFD6E97EE78AF7AA8BA84E20C6523F</string>
-				<string>90379C4D111C3BB8834CC117AD072DE2</string>
-				<string>8F5E62777148745FAFCD9848F2216462</string>
-				<string>CDBD80EB63A3482BF30B876938782D2C</string>
-				<string>9594E7B489E20FA0CE16209AA0D9A33B</string>
-				<string>15F4962BEBC4BA7715C5AEABC392D477</string>
-				<string>ADD429CB6F5F9DE75256086A939119B1</string>
-				<string>2DDF89976DA0A48A2EEA28FFCD90E170</string>
-				<string>307539268B403C5527AD2CAC86EEF51B</string>
-				<string>772264D999738121516654B4232C27CA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>D41D8CD98F00B204E9800998ECF8427E</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastSwiftUpdateCheck</key>
-				<string>0700</string>
-				<key>LastUpgradeCheck</key>
-				<string>0700</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>7DB346D0F39D3F0E887471402A8071AB</string>
-			<key>productRefGroup</key>
-			<string>7213CFEC67C3B1D54FD43442BB4DD2F8</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>44538290913B42364D613A687800DA35</string>
-				<string>614365A9E4840470AC452C75DD2858EC</string>
-				<string>FF39F572578F134BF8414A8D27FD3729</string>
-				<string>9B27914C2D65E7BCA3CAB1D2365E645D</string>
-				<string>7C6A588762CF05921A56DE6635B89C5D</string>
-				<string>9B0124864FA21CEC6CC3F9B3C55B6F65</string>
-				<string>FEC7E09BE7C35F9F8658D953E429D451</string>
-				<string>D7D2E8A3E11B6A93694AEE6F34218DD3</string>
-			</array>
-		</dict>
-		<key>D4471926F81D20E92AAC8F5D7966020C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5B14A01C0088D795DF56061F4DA5C947</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D56B102D752D618E23E784BAC7AFAA95</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3871A7C8372F1322E306860D1430882B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D5F0C6BCB89A7D95ADDDBE8D79996573</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C3A0C86A2E540C585BD9EED8227FC082</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D6A9A933A8C1ECAD3DAFD2A489AD91AD</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>BB34D4B1C2FA534E510E5A6F93EC78C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>D6B1F7F217F77E9186E76925C6CE6D3E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2DE492C558DEBA31064661917BC71BE2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D6DF8079D60BBBC0561EE11B941804DC</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>ABB75716FC955FDA06FCD29DE6F32178</string>
-				<string>F0E76B087E7E5F0C0AC5AA247AB65401</string>
-				<string>3D3655EA84BA51E653305BA5C757DEDD</string>
-				<string>18BB6406DBA51C04A9070E7DAE7CEA32</string>
-				<string>EDD889910ED1B6E47D1D22912539C0C3</string>
-				<string>BAF807493CB41AC83E6E5BF2D65CA107</string>
-				<string>503E3338DF4E754C7E55F6C3B1E3E077</string>
-				<string>13477CD7CE62DA553A65F4E8588AC29D</string>
-				<string>5C897B7691027D6EF6468F249FEF2833</string>
-				<string>2AC4CA10BF5CA4BC515B472AEDE54445</string>
-				<string>F683FDBA6C4E8E68A2779E54F74078E3</string>
-				<string>6147FC5841082B8D142AE6914FB00B7F</string>
-				<string>0ECA27BEBCA1AA178470104FBD0E29D6</string>
-				<string>BFC2B5254C88254A58C95900FBA83AA3</string>
-				<string>275E8986FB7ADB3A095558F0BF433833</string>
-				<string>12057F126FEE11DB7394DA87B1E8ED18</string>
-				<string>A138EAA2EF4367C0E438246F137F7FF8</string>
-				<string>94253F9E40DD9BBE9F3C9329447B4968</string>
-				<string>AF73F748061BE56ED8FDF3F99D0C0803</string>
-				<string>8D3999B3B1E916D957A5C779A5EBB60E</string>
-				<string>7E412D4C2839AA78A37DC16806611918</string>
-				<string>B8E890AC72A2B515423B0873EBA7497B</string>
-				<string>44A9E2D9BDB77A290A874AC9B82CA058</string>
-				<string>EA6916A705334537CA79073B9FF7BA5C</string>
-				<string>85BEA7D91944470D6D27E8F8AFD5DC33</string>
-				<string>F4BE7B053C0D4DC5F1CE34E2BD1D3C5A</string>
-				<string>0CC3868667FB42D9AE0F41894DFF9817</string>
-				<string>B93E360837BF6049E6ADBCB496DD486E</string>
-				<string>70395B0C308DEC6A90B53EDF20802995</string>
-				<string>9ADA5122804C363890866E9689DC09EB</string>
-				<string>33AEE3A4B80BC6D382A80C251AD174C3</string>
-				<string>E5748D29F9391596CDD479CA089F4E1B</string>
-				<string>39BC07ED0F9C8237F0CF879CB5617181</string>
-				<string>79F67FB9CB9E17F8CBF312FA0084EAB2</string>
-				<string>C0A6FE769DB8A583B4AB4F853DCACCB8</string>
-				<string>010C64612B6F3C569DD06BF294943208</string>
-				<string>056D9D725EE24B24614AF91C4E832CE6</string>
-				<string>E3AA96F7AED9BA93194DC007ECEF5253</string>
-				<string>AD4ED07FD9EA0B454D9798F141F5CE97</string>
-				<string>7E53E34B09E745150E50C6A324601EB6</string>
-				<string>A7F78203B95EAC361DD6C18C24D9C6EA</string>
-				<string>625F7B91B276D9AD6E32248D4F1F4861</string>
-				<string>269992A3BB1AD297195CB4C3A382DDDA</string>
-				<string>0F6A376FDBDBE0F5EC0A5DFCA1E41EEC</string>
-				<string>6FD602910C6A4CCF48277C86A835C39E</string>
-				<string>6ACDA50CF7E4AA489A05B943886D1329</string>
-				<string>55803E192FDF33FACEB82F80810AD284</string>
-				<string>7CE43A2B274B3A1C65CA161F632448B1</string>
-				<string>17744F33B9814C0F99CD9610B6F63A3C</string>
-				<string>2CE57331ED99C2D3E28CC5FA7F2E489E</string>
-				<string>EE3F30ED84D01AA3F798CE0FF424F2B5</string>
-				<string>656AF484ECD477CE254E68B0845BE284</string>
-				<string>ADC23C0C5CA9D89EC7970AEA31E22133</string>
-				<string>703A91CA61086D71F395EB4300699E18</string>
-				<string>A5867CFCE263A489500E497E982C98B3</string>
-				<string>13240DAE3074045875C9BF40FA6C2D8C</string>
-				<string>381606C2C2D281EACA05C8A7EE991154</string>
-				<string>E9ED7FE4CE65BB533604E7AD81D236A5</string>
-				<string>932A608D68C76DBCD3887C0428352870</string>
-				<string>F5FD8B227B68EF7C52764E8C8C81A6D1</string>
-				<string>275FF153A051A414EE420FC3E9FB1027</string>
-				<string>2C771E3DEEBCDCCD7642FFBC88F4B21A</string>
-				<string>CFCF19080BB274D8EEF1B5A844B36F5E</string>
-				<string>E78BCA5E5168C44187E2B8A479663BE2</string>
-				<string>8D3EEF1A053E268995FD7ED5169F02B0</string>
-				<string>30EA89C837F36EC0047FF48329CDB9DF</string>
-				<string>83E49E67B149F9FB070BFAC545DEC15A</string>
-				<string>6B702CBA3187CA6D991CBE76351837FD</string>
-				<string>C7173C062C939B53E256CEE89C8C85FA</string>
-				<string>13415C7329C8E3CA1EF501EB6450CF3C</string>
-				<string>04B59445A37377F5D0DF638B75676F9D</string>
-				<string>377230FDD0CDD270BFF84020197D953B</string>
-				<string>B0A9FD2263DA835993FD907E4B4CE2C3</string>
-				<string>D8AB8DFEA14F6A474AAD67911ED5F9AD</string>
-				<string>F6BB3FFD23B8534A7B485A347AFADAFC</string>
-				<string>F0EE7E6B78C9D23E8B022BD87DE056C7</string>
-				<string>569C76844EC991348E682B42B5153E23</string>
-				<string>7847BFC1F539128C32E132CB47172B80</string>
-				<string>AA16F216C37B4D26B2AEBA5318F20F2B</string>
-				<string>60D58A4919924C9ED9BC875A2866FBDE</string>
-				<string>E3399B666DD32E780F2CB38A337B38CD</string>
-				<string>DCBA1326E666BBBBE25A8762C87B5C3A</string>
-				<string>5BFEA69A0915F6918164977C108CBBAF</string>
-				<string>5ECA4DA302151ED29AF5DAD33DF54FA4</string>
-				<string>75E7B15E4542BBAB1CFDDDBD6EA1780A</string>
-				<string>FF235E5B69D1AEE2514F3CE78B761139</string>
-				<string>2F2E1B3CE08387E078A0F574EAEF69E7</string>
-				<string>6A2E2C219DFF6D32C16239EE310606E8</string>
-				<string>FEDF1B082CA033A0952EA3E981B0A9B0</string>
-				<string>24D88A7B7FE5BB4A952752420717A25A</string>
-				<string>6852FC5243339B784056CB637BC1FEAC</string>
-				<string>F11BBCAE8E7A90157F5AE35594336B5D</string>
-				<string>88598E8F88F0DAC9F2DA4B493925178E</string>
-				<string>5ACBDD58CF47ECD8AD16A8E21B38D22A</string>
-				<string>5DCBAB0AEE38AA2F3D5A38E87AAE9EDF</string>
-				<string>66E7C9EF14FDB3049AD6DBADD3D5F546</string>
-				<string>3B396FE81D2359AEF6D965CBD9818B8F</string>
-				<string>FE7D4761ACE3A5A19A2C6CFC4C2D7DF2</string>
-				<string>7B78DDBD2013D33F60F929243F25B565</string>
-				<string>A411B27CFFCA6B4EA5F4A46033C005A5</string>
-				<string>25C05A083F477603B7EA669638EC0016</string>
-				<string>CCE36FB9BC39FC2DA56F7ADB0C6B04D5</string>
-				<string>DF0B0172701409E57A6201CA8FBF0574</string>
-				<string>615ABC9784F0410A0AB3F458224F9374</string>
-				<string>87DD8E5189D29C2A58ADF3FB7B5B0FBA</string>
-				<string>23150967BB721DD3EDF525D42D23C69F</string>
-				<string>D6EDDE62751FFA62ED72081E39D6F19F</string>
-				<string>8AE5D75670141C6CD6BCBD346D5587AF</string>
-				<string>AC00F08A8CDC8D49C2A4DF634C4AA16E</string>
-				<string>E57C18EEA2C6EAAAFC661CC36A08359C</string>
-				<string>35A0DBDABA33B8F9D4E26D70E7FE4DA5</string>
-				<string>F1790D9553734F8D05439D4B89D6FE66</string>
-				<string>EFE9CC2266B78C141870E56568CE0A4B</string>
-				<string>8785D32B23307F4B79618A5F7856F44F</string>
-				<string>106A4BA5EE50593CF0EF869952FF8DCB</string>
-				<string>2372E8B1408EA57F7E143EB87A85881F</string>
-				<string>2707BE20B947454620D28D8E8DC421AB</string>
-				<string>E63D30C2209090D128D2266CC5779DA1</string>
-				<string>9EC42C15F58BCE37BC88E12D6733EF4B</string>
-				<string>D8B0D36D7985B7BAAA81FB480AE40EB1</string>
-				<string>89BA35490BB928E75A9CC8E7A2FA3DDA</string>
-				<string>6AAF23825904D6DFC9229E6C7BD8CA4C</string>
-				<string>8D75B23AA0082EE3BE5054DF283818F3</string>
-				<string>6F1701065113278B4F9EA93F2C4D30AB</string>
-				<string>AF895FF485271D550E4D064A84FB2619</string>
-				<string>E1D340DC7B6235125C738489439509C4</string>
-				<string>23D44BE2351ABF5A8F0A758F9E97591D</string>
-				<string>0C4F3EAA99C096AD1085CA2A48A5DC85</string>
-				<string>3910FCE5221CCE106E07A99766F29D92</string>
-				<string>B30D924AB6FBA8B2DCAC4FC1495CB45F</string>
-				<string>79AB7F257D1569817E550D4098C2E58B</string>
-				<string>BEF4A476C5C6C876B27C5F88A81B5043</string>
-				<string>268CE435B9F2129DDA96FB23522870E4</string>
-				<string>60E0E6A55FB93D1F65E4691E05F2047B</string>
-				<string>5282FD9C9A97C069805A7E22A42BC5A8</string>
-				<string>721A84CDA8546C0571A414907F59A60C</string>
-				<string>DDBA8228316C11F620BEC183CE24EBCC</string>
-				<string>D9B6E88A21A5218B4346387AFDB83F3C</string>
-				<string>7D929FFFFBCE37A90FDFAEDF52FBF97E</string>
-				<string>A4FE2267F0D28CB4EDFF93E2BEA9E8B6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>D6EDDE62751FFA62ED72081E39D6F19F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D94C88848C57B60ABE5E9867B1942078</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D72318DBF092553E249C7DEA4BD4BEA0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D7500103A9FAA223279359D5F701B1CA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CB32E46DA8057A3A622F29F4500772A2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D7D2E8A3E11B6A93694AEE6F34218DD3</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>6D7B567D2F85E5F4E1BEA8ECF23B62CC</string>
-			<key>buildPhases</key>
-			<array>
-				<string>D3F77243EF52EC5DD00A359FD77D68F2</string>
-				<string>64F36D028C5B6F656BB7F9D8DE2CB4F4</string>
-				<string>D6A9A933A8C1ECAD3DAFD2A489AD91AD</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift</string>
-			<key>productReference</key>
-			<string>638D81BBC0A578B83C471D806B095768</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>D859CDF029BE59A16868AB0E614D41BB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTableViewReactiveArrayDataSource.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D85E2176535BD6BEB9DC135A7F8B1C18</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CE5313DC68E5A2FFE47DB9B6FC673E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D874BCA6EE22322AFBF24C21422A224D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>8E7CDAC755EB5A725153296B2E243630</string>
-				<string>BC48F2F74FDE1124DE6CA9C516A65F1E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>D8AB8DFEA14F6A474AAD67911ED5F9AD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D368C07F4793B141BBE46A5B8453B177</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D8B0D36D7985B7BAAA81FB480AE40EB1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3ADD86DB658ADA7B22F4A9E9D1DA25A8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D91B8FB88CC735C3CC651A2DDAA219E5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable+Concurrency.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Observable+Concurrency.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D92B1754DDCAEF92566DAC3592014D73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CCFDBBFF08F74F9511DF21F873EABE86</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D94C88848C57B60ABE5E9867B1942078</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SingleAsync.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/SingleAsync.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D9688474E44B841F6129B4FAFFB2C565</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ObserveOnSerialDispatchQueue.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ObserveOnSerialDispatchQueue.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D9B6E88A21A5218B4346387AFDB83F3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>713CD0C782C89D147C113A835FA5BD81</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D9CDE42D609590B6AA8AAD038BF20E21</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>TakeWhile.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/TakeWhile.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D9F0A2FEE585A9018680D5769208A755</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Concat.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Concat.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DA208E4396D571B3FF2C758E089F3C95</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Observable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DA600661558FFEB04BB1DA6E56D7BA9A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>42922C460C6B4921C335F9A0AB78966B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DA6D897F503A3460A4E195622BACB277</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Debug.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Debug.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DAC73301778EBDD3A376AB81B1706375</key>
-		<dict>
-			<key>fileRef</key>
-			<string>70C8BBEADC28B99A09E31C0BC5FE57FD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBD5C714DE2DE3862DE6DD9ABF4BA0E0</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_RxGesture_iOS_Demo.framework</string>
-			<key>path</key>
-			<string>Pods_RxGesture_iOS_Demo.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>DCA27732462FA9070AE710D9A361ADA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>383E8395E05602750FB92C87A2FDEB92</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DCBA1326E666BBBBE25A8762C87B5C3A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CA682272C2916EFCE819012AA8F6F4C6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DD0BF625CE8A09C228BDA4F907267DA2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UISearchBar+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UISearchBar+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DD3230BF944AB4C33C9399E620557C07</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EB39ED08E4C74181954C6B42D69F7FB7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>DD670E6BA419147639CA62FC8C3CEDA5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Platform.Linux.swift</string>
-			<key>path</key>
-			<string>RxSwift/Platform/Platform.Linux.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DD67C1AB5326A859DF36368BF25BED53</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DDBA8228316C11F620BEC183CE24EBCC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0522CD8F0D5EA4DD356A6C34B68879AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DDF30573D7664E73624011D0DAD860C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE379A21FCEBCEC0E0E426D9A123F760</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE379A21FCEBCEC0E0E426D9A123F760</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Driver+Operators.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DE4BF2809DFC533229426FC2B1D4AF91</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTarget.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/RxTarget.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DEBACD931A5946D126B0215F2E5490E9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E145F810DEFF07BCE812538BFA651708</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DF0B0172701409E57A6201CA8FBF0574</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6E0C7DD780E181D0F5EB28D77EDB199C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DF3C7C58743CE4D5B3CC5515C5803942</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>HistoricalSchedulerTimeConverter.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/HistoricalSchedulerTimeConverter.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DF644BC19728B14C164A989F9C370CDC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9EBAC0789FA5CD3B9A97859B6633DD22</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DFDC7869C929289A9CD3A92B63C692D1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AnonymousObservable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/AnonymousObservable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DFF7AC2C01AE58822F964F3F439067AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>83425313765F7ED109DC81D7BADC7B5A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E04FB4107DD3A5DCF1062A8E82ACA4F3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>70AF53C1EA75011D56334E4AB4C72E91</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E058D4EBE0ECDD108B8578F0C62D285A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ControlEvent+Driver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/CocoaUnits/Driver/ControlEvent+Driver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E0BD34020D1CF5E582610A08BF646C57</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>Pods_RxGesture_OSX_Demo.framework</string>
-			<key>path</key>
-			<string>Pods_RxGesture_OSX_Demo.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>E145F810DEFF07BCE812538BFA651708</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ShareReplay1WhileConnected.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/ShareReplay1WhileConnected.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E19FE5C08FA3F61711C410D13B756BA0</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>9B27914C2D65E7BCA3CAB1D2365E645D</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift</string>
-		</dict>
-		<key>E1C544817D76E71D828DB3AE0EE5DFA3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>InfiniteSequence.swift</string>
-			<key>path</key>
-			<string>RxSwift/DataStructures/InfiniteSequence.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E1D340DC7B6235125C738489439509C4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B54EEB7F3D9B9D4D2E5708405A57F65E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E2EB128A6BB718BA85611E62366C103B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CB48DAD7D5163991153C05BD30040B6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>E32F9EEBC2569CC8B22C59582C0E2D35</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E3399B666DD32E780F2CB38A337B38CD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>65D1EB659125EA3969D59014B9F4E1A4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E34A5CB470BDF4610D116B4C6E6310CC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Using.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Using.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E3AA96F7AED9BA93194DC007ECEF5253</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C862CF3BD7290855D8AD7565CD8E2666</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E3C9982D23DD01F4E2153362830857AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>89361C46E5D991265A6D4AECA7F2EAC4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>E3E5A164068D5B2AAA03B81990810232</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3E98F8FEECEC2DD9F966C9D3E8807071</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E409A63713B84552678935C3B2FB066C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8267675773E498B54102DEDDB7B15C3E</string>
-				<string>3E11B5F9407F2460BF507A031F543A31</string>
-				<string>A36FEB7BB3E2CD50B80A49D235925AF3</string>
-				<string>5F73DCC6D3F37BDB0EE4D0E020E4901D</string>
-				<string>40731FA149D0C969EF2ACC2B814AAA39</string>
-				<string>F46C790F82DD42B1C1A090BF739A5BC5</string>
-				<string>D1541DD57D56EB09CEF071E8D1144E48</string>
-				<string>41262CC4216C45247331AC963D084351</string>
-				<string>AFE010FEC036F74911E6F9609402C03F</string>
-				<string>A0F993C4C6D6C90DB6204A41E10A910E</string>
-				<string>DD67C1AB5326A859DF36368BF25BED53</string>
-				<string>810CDFDD1F29B38A57A777A0E34E51F3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E49783BB78FFE662360F74DB16C026FC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80464EA0B50C6A06A9C5061AA0E72B6E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4DCA1F1EC467C456DE2F6B57B5C35A6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Timer.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Timer.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4DFD6E97EE78AF7AA8BA84E20C6523F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A3B83162A671B863092C509640455BB1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F716E7B90B006A0A58F63CC6266D4D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6FD15299911C10004D6C338D4883BEA6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5748D29F9391596CDD479CA089F4E1B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>52DE9731E7AB29C0A4F4994F544D31EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E57C18EEA2C6EAAAFC661CC36A08359C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C3A0C86A2E540C585BD9EED8227FC082</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E592BE42F6C322EF48759A3D652B83BA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E5AAEEC20D987248D63ADAEC556054C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE4BF2809DFC533229426FC2B1D4AF91</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E60ED422014F151D85A4DE0D0090BED2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>26AAE4981F2B2A0B345D49C6FFF3F191</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E63D30C2209090D128D2266CC5779DA1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B26A5D41DBB998BC91E988B0B68FFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E647F4CE6EFA1262239A58D3F8795293</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>5F73DCC6D3F37BDB0EE4D0E020E4901D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.3</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>@executable_path/Frameworks</string>
-					<string>@loader_path/Frameworks</string>
-				</array>
-				<key>MODULEMAP_FILE</key>
-				<string>Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_NAME</key>
-				<string>RxCocoa</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>E72B0C0D6CBD12E8A5F21B72CDDD7203</key>
-		<dict>
-			<key>fileRef</key>
-			<string>442E13A5AA3E5B956BF394857AB8456C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E7731A4628E596D95ACD0AFE6EEBBA43</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Filter.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/Filter.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E77B1193C404678CFF0564269C0E172E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>97C61F2EABC0E0556306C355CAF9A9DF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E78BCA5E5168C44187E2B8A479663BE2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACDB236E3E70B35781D525D0318E5BB7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E8501FA1970C16E7C772C02D8159FC00</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AD57AA83FCA2E0F8E94E8CAFC455341C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E9ED7FE4CE65BB533604E7AD81D236A5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1B3B751B0C5F626CB6E8FCE543FF5CF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EA6916A705334537CA79073B9FF7BA5C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4A2B40CC335CF4F90488701FB34D321D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EB04FF1B2FE87A99D524B3A353ADC3EA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9D561015C9DD423C4695CE8F7CAE062</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EB2A84A5948EBF2DF07E8C6C1535F69C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8BF27BBCB2AAD5C679581C38EE2DC185</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EB39ED08E4C74181954C6B42D69F7FB7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>_RXKVOObserver.h</string>
-			<key>path</key>
-			<string>RxCocoa/Common/_RXKVOObserver.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC09866E2A98A4329F1656536A729543</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>D41D8CD98F00B204E9800998ECF8427E</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>FEC7E09BE7C35F9F8658D953E429D451</string>
-			<key>remoteInfo</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture</string>
-		</dict>
-		<key>EDBB3142C058BFF8F0B79E20C43D86F8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>SynchronizedDisposeType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Concurrency/SynchronizedDisposeType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EDD889910ED1B6E47D1D22912539C0C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DFDC7869C929289A9CD3A92B63C692D1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EE3F30ED84D01AA3F798CE0FF424F2B5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>32333103781E0D7296DE45160EFFCF8A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EF3D61D08F8C97E0BBC4BB5E0115CC6C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>FA705E2E270100E5C40A74D6DF388F71</string>
-				<string>8E4DD36D597C752EBB6051DF7A6258A2</string>
-				<string>DD3230BF944AB4C33C9399E620557C07</string>
-				<string>75DCFE5F338EA7396929204D17363C5F</string>
-				<string>1035B16F5AEAD95D6CE0D08BF42A068F</string>
-				<string>E3C9982D23DD01F4E2153362830857AF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EFC5A0F424A48800CFC4B62F20F6A218</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>BEE7FA81B3281D16D65348F06A05E393</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EFE9CC2266B78C141870E56568CE0A4B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AE2DE95184E55408F0BFC4D170AF4C04</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F06E6FB5C72FA43030789513F4821926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2F709B0640631738B641635327262486</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F0C4B9D95966A3DD638408DD2AC9A1C1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UISwitch+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UISwitch+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F0E76B087E7E5F0C0AC5AA247AB65401</key>
-		<dict>
-			<key>fileRef</key>
-			<string>920C57CA223DED99EA2B9BF7416E8664</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F0E9F066503AC19C46BC1AA084BAFD15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3D1D85D88F45DA1940997764A3F22DA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F0EE7E6B78C9D23E8B022BD87DE056C7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>70C8BBEADC28B99A09E31C0BC5FE57FD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F11BBCAE8E7A90157F5AE35594336B5D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CAAFF37D2CE77D76494B7F42ABF4792A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F150F627FA22644A5A75B5B046FF3B6B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>60F618BDF7BC2AC6CC2A49F4069E5944</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F16FBB4B6EC68C9609A904B8BE63BA36</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C686CEFDB56AF5DFB18118006274FA02</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1790D9553734F8D05439D4B89D6FE66</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8A2FE6EDBAF67DE1651CFA7C30C0FA9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F17C36EE5E47C26D58ACC1C16C169A83</key>
-		<dict>
-			<key>fileRef</key>
-			<string>06063B1BB0E18FA159CEC26B2275178D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F20316FCE33298DCDDE596E17F8ABF9B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIBarButtonItem+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIBarButtonItem+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F2C2A9E19936B336BC0C7AE82D875826</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTableViewDataSourceType.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Protocols/RxTableViewDataSourceType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F300A6D9B9E5AE90DC83258DC5E63E53</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3CB24918AFDA96F22951E15B52F35A8B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F42EBA332695D4D99D6D6AE0531E8476</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D94C88848C57B60ABE5E9867B1942078</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F46C790F82DD42B1C1A090BF739A5BC5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F4BE7B053C0D4DC5F1CE34E2BD1D3C5A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DA6D897F503A3460A4E195622BACB277</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F5079F022D850EE97985FE670AE654D3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSURLSession+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/NSURLSession+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F52B7AE23C229717D736C40F90B8D574</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>AnyObserver.swift</string>
-			<key>path</key>
-			<string>RxSwift/AnyObserver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F5FD8B227B68EF7C52764E8C8C81A6D1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7E897AFACD8C7C5E2A001D27DE0B4618</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F60D78F33A072FBB5C97E5841B867C77</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>HistoricalScheduler.swift</string>
-			<key>path</key>
-			<string>RxSwift/Schedulers/HistoricalScheduler.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F613E3B025F9B61C1CAB05CA71EA6B22</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxSwift.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F61BF2C739E958D5E5D08C55E5EAF0F8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>371997EFA02B3641F6F5DCA3462F231D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F683FDBA6C4E8E68A2779E54F74078E3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6B52DF800B19E074DBC494C3F9A24063</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F6BB3FFD23B8534A7B485A347AFADAFC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8D3FD3990B8A1E9548CB62F43886EADA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F748183552175B762FB45CE31A2F53FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxImagePickerDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxImagePickerDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F788295A8CDD83CDBE32E83DFE9AF945</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxSwift.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F7C711FE0E199D267B5A4E427D1FF097</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F7D7F0E69267A2EC33065AC12526C089</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A16B90AA9D152514C8ADF7451C1E90A4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F86837682196263E9D5F287348EB7B59</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FDF08F5702058168441B64713EBBB29D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F86FFCA66ED86F404880F6B796F87F05</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>Platform.Darwin.swift</string>
-			<key>path</key>
-			<string>RxSwift/Platform/Platform.Darwin.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F8B7F8C036BA9171F3B199A086D94A88</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>name</key>
-			<string>Info.plist</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxSwift/Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F8CC9CB96DA7D4844F559C8C80088CD4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9EEA1B9C1EA4C125354E33390B6E85E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>F90193FA637C5E3C76DCF1888950DB2C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>CombineLatest+CollectionType.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F9E699138D97A7B8FB51A1169458CC5B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>UIRefreshControl+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/UIRefreshControl+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F9EA78A1A667DF3843D7E1F2D6630F38</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4DCA1F1EC467C456DE2F6B57B5C35A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FA705E2E270100E5C40A74D6DF388F71</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BC5384AAA357E269F58CCF248EF00C45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>FA9E64EF1F16C9A75321D321AB87C4A4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>45EC70652ECAA2EB6A5CF971D91B21FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FB5C6A9BAE45FFA2C75DC00EC9F9430F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RefCount.swift</string>
-			<key>path</key>
-			<string>RxSwift/Observables/Implementations/RefCount.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FBC2B3604E156C2B39FB243BDBF5FBDC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FBE1FA148B8A7875D8A705D0C9804762</key>
-		<dict>
-			<key>fileRef</key>
-			<string>72024E9C45ED7ABA10282FBC2A8B6CC9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FC3A97DF6DC20E8FA7115AF427A1FDA3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>ScheduledDisposable.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/ScheduledDisposable.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FC726DC55B0CC8247FECC7370424A3AE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DF3C7C58743CE4D5B3CC5515C5803942</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FCCAD7210551E7E315057FE92B71710C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A7485BC75D5D55862531507EA811F6BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FD1A57E1C3EFB8080B64032CEBA6EEBA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h</string>
-			<key>path</key>
-			<string>../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FD3053D58B4B90A6385906722E65D5E5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>245AC5100739C5A8E44FBFE74CCCCC12</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FD62880460C77E0A9BAF5FCF3EB7E4CA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20587B5EBF4383E9A1A39FA525D0213B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FDA6B4837F238135EDBB1FD219AC21E8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>DisposeBag.swift</string>
-			<key>path</key>
-			<string>RxSwift/Disposables/DisposeBag.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FDEB61CDD7978740C1A32E03C8A96C40</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>NSObject+Rx.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/NSObject+Rx.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FDF08F5702058168441B64713EBBB29D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>MessageSentObserver.swift</string>
-			<key>path</key>
-			<string>RxCocoa/Common/Observables/Implementations/MessageSentObserver.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FE1DCEC4B3D1DAFFC879A8BAB2E0B13C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.swift</string>
-			<key>name</key>
-			<string>RxTextStorageDelegateProxy.swift</string>
-			<key>path</key>
-			<string>RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FE463EC4F9832060D985F73596AD1F98</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-RxGesture_iOS_Demo.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FE6A06583DCAD5929380A73780693C1D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FDF08F5702058168441B64713EBBB29D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FE7D4761ACE3A5A19A2C6CFC4C2D7DF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C7A741BE56BF66F4F2242CF3B34F1E6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FE98B056871B5E87824C85DEFB8AB99A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>976CED50E8A41F564ABC9D9722A9B749</string>
-				<string>922DA1B8B35C278C5E7E06E5EC5D9D74</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>FEC7E09BE7C35F9F8658D953E429D451</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2A940E69BC5371EEA2C7CCEACA25AB6C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>40278FBAB194366C10D902746F0AEC7B</string>
-				<string>39FD8BDAE7CFD0A590BD823D434061A3</string>
-				<string>87D45D1CEF140D8687BAE10B04EF8E34</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>37DE1A019926E248B0F8C4BFA0957231</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_OSX_Demo-RxGesture</string>
-			<key>productReference</key>
-			<string>8BC1538A9C562465360DC7DEE22C8AB0</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>FEDF1B082CA033A0952EA3E981B0A9B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6A7E2B288AEF9F04DA4D3DAF5B40E7F1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FF12F2A0C3DB5BC71502F2741134C221</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>B073BB08B89B47C6FAC0A2BC30BEB5EC</string>
-				<string>1F8E6558BAC2C93227F65E3870B19264</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>FF235E5B69D1AEE2514F3CE78B761139</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3426C8436E0E44F1E70A1F7BC6D4BF63</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FF2C60939A60815A9D77688C30A55CE9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0C9289AF05996A8D7D12EAAF8869DBA2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FF39F572578F134BF8414A8D27FD3729</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>77A85EF82F6A93E9EBFCD97A800D30F0</string>
-			<key>buildPhases</key>
-			<array>
-				<string>BD2F6DF7E83A8F2FC1A44E6FED0C1B6A</string>
-				<string>FE98B056871B5E87824C85DEFB8AB99A</string>
-				<string>E77B1193C404678CFF0564269C0E172E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>A8B8C84A3664BFD488DDAC8393D52116</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture</string>
-			<key>productName</key>
-			<string>Pods-RxGesture_iOS_Demo-RxGesture</string>
-			<key>productReference</key>
-			<string>8BC1538A9C562465360DC7DEE22C8AB0</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>FFE6FFDA3FB700D8A1F431F6BE633F21</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>1799597E775C55C9969167456E64659A</string>
-				<string>E647F4CE6EFA1262239A58D3F8795293</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>D41D8CD98F00B204E9800998ECF8427E</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		00F8A441477F0B251EE61CF7A98BED9B /* DelegateProxyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12DB9FC05ECEBD079763E18E22438A0 /* DelegateProxyType.swift */; };
+		010C64612B6F3C569DD06BF294943208 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20587B5EBF4383E9A1A39FA525D0213B /* Empty.swift */; };
+		01803CDE548981116E7A943E1E109A39 /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87E53818AF138ACF5D61B3D7D6E5274 /* Skip.swift */; };
+		01E61E8DC081EA6C0009BBD7057D29C1 /* Observable+Bind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2488AC35E99BBB5538B1BD95F7655E94 /* Observable+Bind.swift */; };
+		0305F269FD99A7E9B15020CDE7EC04AC /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2576CF8363182027D6275CCCF79BFF09 /* UIProgressView+Rx.swift */; };
+		04B59445A37377F5D0DF638B75676F9D /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1791E2917EF6FCE255F4894FA8AD /* ObservableType.swift */; };
+		056D9D725EE24B24614AF91C4E832CE6 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4122641759BCB149F3FCADD5C3268F7 /* Error.swift */; };
+		05B217FDEBD05EAF43320C9D44E5D002 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F709B0640631738B641635327262486 /* DelegateProxy.swift */; };
+		05BD51B2599DFF8C9D77DF9CCAB2F8CD /* RxTableViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C2A9E19936B336BC0C7AE82D875826 /* RxTableViewDataSourceType.swift */; };
+		05C4DDCFD41B0362192795C66D54E2D4 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63811859DE646A04ED30107BC30950A /* Multicast.swift */; };
+		065D3BEF76FFE3B3DF7B72302D5D7DB0 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64491ABA744A4BD99C4CB1D733B5DA3 /* RxMutableBox.swift */; };
+		07537B3412788F76A1CADAE162264580 /* UISegmentedControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2B0DA384E6A125B6430754BD9E8241 /* UISegmentedControl+Rx.swift */; };
+		077B2088D0B86F82BDEBA1EBFAE9669A /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB4F5995EE9165EFF01A1B67E31329 /* AnonymousObserver.swift */; };
+		08D2BF0199EBBCEC535A63481EEA6E5E /* UIScrollView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C99CE41C2C08F13D0EFB93F9F1AA297 /* UIScrollView+Rx.swift */; };
+		09B3B057734A3D96C3EFDEA6F6098411 /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A741BE56BF66F4F2242CF3B34F1E6D /* ScheduledItemType.swift */; };
+		09DE898823F74CB06BE5792F0CC7D1B6 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0905B95004BC92DB93247A62B00B3165 /* Map.swift */; };
+		0AA76BFB01DDC6C4DC5206BAAFB02AB5 /* ControlProperty+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDA9865788B870D2E0C9631A55AD2FC /* ControlProperty+Driver.swift */; };
+		0B4B7D83E73B0AA1350996A9C1A69BE3 /* NSTextField+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E46C8CA6BBF11ADED61F1E96D33D598 /* NSTextField+Rx.swift */; };
+		0C47F7A3A711DEF2852287E958912400 /* UILabel+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDB7B436E22D693CB5360DB88CE7450 /* UILabel+Rx.swift */; };
+		0C4F3EAA99C096AD1085CA2A48A5DC85 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880EC46B2EA4171F124091B6A8EEC9BE /* Throttle.swift */; };
+		0CBCDC693500CA15D126A035DB4D4367 /* RxTextViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E0F99179E5CCB68C4721ECC9703E40 /* RxTextViewDelegateProxy.swift */; };
+		0CC3868667FB42D9AE0F41894DFF9817 /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80464EA0B50C6A06A9C5061AA0E72B6E /* Deferred.swift */; };
+		0CE1F2ABB8602030A1F03084D04D59C5 /* Pods-RxGesture_OSX_Demo-RxGesture-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6125CFE9D1577552DB75431F0817A868 /* Pods-RxGesture_OSX_Demo-RxGesture-dummy.m */; };
+		0CFA33E64D14743BE85F0223890703FF /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036645378416B45CDB8CE10B07BE2213 /* SerialDispatchQueueScheduler.swift */; };
+		0E6188767C3FAF3698E2230366164E66 /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09F8FD785663489A532E8A69164E9C /* SynchronizedUnsubscribeType.swift */; };
+		0ECA27BEBCA1AA178470104FBD0E29D6 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBAC0789FA5CD3B9A97859B6633DD22 /* Buffer.swift */; };
+		0F0D9C24C0E44E57008ED781A6A9540A /* NSObject+Rx+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFDBBFF08F74F9511DF21F873EABE86 /* NSObject+Rx+RawRepresentable.swift */; };
+		0F6A376FDBDBE0F5EC0A5DFCA1E41EEC /* ImmediateScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3923EA7357FC6223BC856AAE0F07580 /* ImmediateScheduler.swift */; };
+		100E0FBCFBCB8BE4FEBE0CC293730203 /* Observable+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7968685A24D6C361EE9E76D7D17C454B /* Observable+Creation.swift */; };
+		1035B16F5AEAD95D6CE0D08BF42A068F /* Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 810CDFDD1F29B38A57A777A0E34E51F3 /* Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		106A4BA5EE50593CF0EF869952FF8DCB /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FED2EC4C912C80F8F0A4FE9E545CB4E /* SubjectType.swift */; };
+		12057F126FEE11DB7394DA87B1E8ED18 /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0081C0EB913B4A12C9BA7F9E2C44CA /* CombineLatest+arity.swift */; };
+		13240DAE3074045875C9BF40FA6C2D8C /* NAryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714C5305FFAFC2F0793D969801E49179 /* NAryDisposable.swift */; };
+		13415C7329C8E3CA1EF501EB6450CF3C /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867FB6D9CD5ADD06727AA1E89197078D /* ObservableConvertibleType.swift */; };
+		13477CD7CE62DA553A65F4E8588AC29D /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42922C460C6B4921C335F9A0AB78966B /* AsyncLock.swift */; };
+		13DAA72FFC4FEC8282FF159AF25E6C3C /* _RXDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4249BCB52EA315CF45C8AF750220C3 /* _RXDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		14E592CECFBE338044522B24E1481FE6 /* Pods-RxGesture_iOS_Demo-RxGesture-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B7233B7F267BF399EEED6714BCE42D /* Pods-RxGesture_iOS_Demo-RxGesture-dummy.m */; };
+		14F0CB6A70A3D96F1C4BE2E5CCF9C2C4 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E010F7B88BB02E629463A73BA403E1 /* Disposable.swift */; };
+		1514F07E372FBDC4AC1D948329D062B3 /* Pods-RxGesture_OSX_Demo-RxSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 58ECEFE2F4CC184ABFE4A7BD4F63F568 /* Pods-RxGesture_OSX_Demo-RxSwift-dummy.m */; };
+		153315CB7CE0328B96834073C4C53691 /* Pods-RxGesture_OSX_Demo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8822B80A6A868B58E68512A9C1288FC8 /* Pods-RxGesture_OSX_Demo-dummy.m */; };
+		15B5E4C3EFE2725A54E98104C2781351 /* Pods-RxGesture_iOS_Demo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D72318DBF092553E249C7DEA4BD4BEA0 /* Pods-RxGesture_iOS_Demo-dummy.m */; };
+		15F4962BEBC4BA7715C5AEABC392D477 /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA6793E8440943D0A3CE5EC20DCC7FC /* Window.swift */; };
+		17744F33B9814C0F99CD9610B6F63A3C /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = B746BEBFCD9CFA793E10E15D5E7B47D4 /* Just.swift */; };
+		18570A91E717C6ACB651EF74D1504147 /* RxTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4BF2809DFC533229426FC2B1D4AF91 /* RxTarget.swift */; };
+		1897D796678C177CDE2943A913694DA1 /* Driver+Operators+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71AFAD963301C46BC7BC87E5B3D2F396 /* Driver+Operators+arity.swift */; };
+		18BB6406DBA51C04A9070E7DAE7CEA32 /* AnonymousInvocable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8FE7D88F5AF65F3E6D57C39B12F30 /* AnonymousInvocable.swift */; };
+		18F6CBEA55853D5400671FFC872FEB8D /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3A97DF6DC20E8FA7115AF427A1FDA3 /* ScheduledDisposable.swift */; };
+		1A6B5613B12EDBA017A9204D949A4D2A /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937967AE1F14874EF338B1B8F57AA23B /* UITabBarItem+Rx.swift */; };
+		1B4A8D83F816BC448322BC0057DAA019 /* DeallocObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4F910A4EF4840DF1A5FA245812BEB1 /* DeallocObservable.swift */; };
+		1C2DB5C4B575F0B74C596E23A59C934A /* RxGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D561015C9DD423C4695CE8F7CAE062 /* RxGesture.swift */; };
+		1DEA721BCEC873F79234C5E63F2548B8 /* Driver+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A12623F1AB0752800B1DB10DF0417CF /* Driver+Subscription.swift */; };
+		1E5FB7BCA876FA81FC36980DBF774826 /* NSImageView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1769EE025DD222C127D3D32B83C90BC0 /* NSImageView+Rx.swift */; };
+		1F76BDB26F35646A511521BFC163D808 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7731A4628E596D95ACD0AFE6EEBBA43 /* Filter.swift */; };
+		20C06CF74646A61B0C5EFF0F626C346F /* _RXObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CD8DFA3BDA378BDC5FF885379349130 /* _RXObjCRuntime.m */; };
+		23150967BB721DD3EDF525D42D23C69F /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06063B1BB0E18FA159CEC26B2275178D /* SingleAssignmentDisposable.swift */; };
+		2372E8B1408EA57F7E143EB87A85881F /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23025D7CBEA011BDDB9A5ECF666C1E8 /* SubscribeOn.swift */; };
+		23978FC6352310883C0A2876EB707671 /* RxSearchBarDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2DA45028046C38FA03EA5A688E9AB4 /* RxSearchBarDelegateProxy.swift */; };
+		23D44BE2351ABF5A8F0A758F9E97591D /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CDE42D609590B6AA8AAD038BF20E21 /* TakeWhile.swift */; };
+		23E941CEBFF4F79C8A915B8ED8FD1827 /* UICollectionView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1CF70E522B6D4494C37B1C06F6D3 /* UICollectionView+Rx.swift */; };
+		242CF41A195F0BFA5D26BA5901A077EA /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2DE95184E55408F0BFC4D170AF4C04 /* StartWith.swift */; };
+		24D7C3299CAA95F0C27AEB129A52E6F1 /* _RXKVOObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = EB39ED08E4C74181954C6B42D69F7FB7 /* _RXKVOObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		24D88A7B7FE5BB4A952752420717A25A /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6AB6AEB9265AFCBF6B63FE10D75B45 /* ReplaySubject.swift */; };
+		2548DC0992B55BE1E01A3957E8DD6D31 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7E2B288AEF9F04DA4D3DAF5B40E7F1 /* Repeat.swift */; };
+		25C05A083F477603B7EA669638EC0016 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666CEAE2C63819EF5FAC680D6243A456 /* Sequence.swift */; };
+		260BDDD7A70035E73256485415DEEAFF /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D859CDF029BE59A16868AB0E614D41BB /* RxTableViewReactiveArrayDataSource.swift */; };
+		268CE435B9F2129DDA96FB23522870E4 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A47B3D1B773D68299EDABB9A4D54E96 /* Variable.swift */; };
+		269992A3BB1AD297195CB4C3A382DDDA /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3C7C58743CE4D5B3CC5515C5803942 /* HistoricalSchedulerTimeConverter.swift */; };
+		26FDC717A2FA97E2A878CCE2092994BC /* ControlEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DD1AB167A06B315005919A9BD6E8B4 /* ControlEvent.swift */; };
+		270525BB31443A4DDFBC264C35F83AA2 /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D368C07F4793B141BBE46A5B8453B177 /* ObserverBase.swift */; };
+		2707BE20B947454620D28D8E8DC421AB /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9289AF05996A8D7D12EAAF8869DBA2 /* SubscriptionDisposable.swift */; };
+		27319C465E633116B267CA247084A624 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C813650AFCAACE69C0BBAF5A9D251 /* Lock.swift */; };
+		275E8986FB7ADB3A095558F0BF433833 /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25308CFE7CECE3CF7E9AC0EBBD33AF9 /* Catch.swift */; };
+		275FF153A051A414EE420FC3E9FB1027 /* Observable+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B8FB88CC735C3CC651A2DDAA219E5 /* Observable+Concurrency.swift */; };
+		2A1CD5FC5B38CC1653414E3AAA7A02B3 /* KVORepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8C262F7B62C28B263F49AACFDFAB2D /* KVORepresentable.swift */; };
+		2A61A0A93B128DEAA575ED886869D432 /* KVORepresentable+CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54133C9D54D6BD5ED81DAE23B47861CA /* KVORepresentable+CoreGraphics.swift */; };
+		2AC4CA10BF5CA4BC515B472AEDE54445 /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA440FABEECC06934002C5B7DFFD96C3 /* BehaviorSubject.swift */; };
+		2B0D27F069E8F0E701A6C9CDD3F57504 /* UIBarButtonItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20316FCE33298DCDDE596E17F8ABF9B /* UIBarButtonItem+Rx.swift */; };
+		2C771E3DEEBCDCCD7642FFBC88F4B21A /* Observable+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7968685A24D6C361EE9E76D7D17C454B /* Observable+Creation.swift */; };
+		2CE57331ED99C2D3E28CC5FA7F2E489E /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C813650AFCAACE69C0BBAF5A9D251 /* Lock.swift */; };
+		2D92995D37170EFA5808AEF0155AB522 /* NSButton+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B5C8CFEFFB40F36662FA6FE88DAF1 /* NSButton+Rx.swift */; };
+		2DDA95E846507AC77F703CA51635C9B7 /* NSObject+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEB61CDD7978740C1A32E03C8A96C40 /* NSObject+Rx.swift */; };
+		2DDF89976DA0A48A2EEA28FFCD90E170 /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713CD0C782C89D147C113A835FA5BD81 /* Zip+arity.swift */; };
+		2E0F6361F3899645D43F388A5C267D4C /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223D2D9A89527A00F2C9592CF7FE7DFB /* SkipWhile.swift */; };
+		2E4A651B3831DC039C0967839B8DE460 /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3FD3990B8A1E9548CB62F43886EADA /* ObserverType.swift */; };
+		2F2E1B3CE08387E078A0F574EAEF69E7 /* RefCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5C6A9BAE45FFA2C75DC00EC9F9430F /* RefCount.swift */; };
+		2F4CB61EB466CCEAFBC662A76FE12D81 /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A10A251161E99CA06BFBA191386FB4 /* RetryWhen.swift */; };
+		2FE889C233DB3D6EE9B795A6B49DEBF2 /* NSView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731149DD4332983A51195DAE8684A126 /* NSView+Rx.swift */; };
+		303BA170CFDE25D980D0B4DA54BDAB58 /* _RXDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 49FBEB4800AA72C5B24F339E2CE4492A /* _RXDelegateProxy.m */; };
+		307539268B403C5527AD2CAC86EEF51B /* Zip+CollectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D04517DD6AD2781E4CB927E673828D5 /* Zip+CollectionType.swift */; };
+		30EA89C837F36EC0047FF48329CDB9DF /* Observable+Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1371EDFFD119B102C16B66F5769F97F0 /* Observable+Single.swift */; };
+		32CC0E764B6FDD289813E6A11F422622 /* Observable+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F86A42574378E3C19BB20A1D4F6EE1 /* Observable+Debug.swift */; };
+		33AEE3A4B80BC6D382A80C251AD174C3 /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA6B4837F238135EDBB1FD219AC21E8 /* DisposeBag.swift */; };
+		35A0DBDABA33B8F9D4E26D70E7FE4DA5 /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223D2D9A89527A00F2C9592CF7FE7DFB /* SkipWhile.swift */; };
+		371DDD0CEF02B7460E792887795AE23C /* Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C711FE0E199D267B5A4E427D1FF097 /* Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		377230FDD0CDD270BFF84020197D953B /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B57D8DB71BDAB80D01EB772BB8B51EC /* ObserveOn.swift */; };
+		381606C2C2D281EACA05C8A7EE991154 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442E13A5AA3E5B956BF394857AB8456C /* Never.swift */; };
+		38B3C9CDAAF67C93B531598DCF0ECC15 /* RxCollectionViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F88D395752826616234A8383CBDCA3D /* RxCollectionViewDelegateProxy.swift */; };
+		3910FCE5221CCE106E07A99766F29D92 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A938D2640AAB94C102006232D3177B /* Timeout.swift */; };
+		39BC07ED0F9C8237F0CF879CB5617181 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41691D1578A4288F5D547260BF7422E4 /* DistinctUntilChanged.swift */; };
+		3B396FE81D2359AEF6D965CBD9818B8F /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419FD89DFCF42A6ADFE86D2D84B0EA46 /* ScheduledItem.swift */; };
+		3B60F86E57C6E0B5EB1C16329497CA38 /* NSURLSession+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5079F022D850EE97985FE670AE654D3 /* NSURLSession+Rx.swift */; };
+		3C7AC628FB1EABCBB60604EF5F9E9DDB /* Observable+Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E897AFACD8C7C5E2A001D27DE0B4618 /* Observable+Binding.swift */; };
+		3D3655EA84BA51E653305BA5C757DEDD /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC81FC6ADF84CBF9D24DF18F08820B7 /* AnonymousDisposable.swift */; };
+		3D98B80CA17B506B8C1B759D6A10E049 /* UIApplication+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6B788D60B66AC712BFEF712D9BE4B2 /* UIApplication+Rx.swift */; };
+		3DC2B0E80E48647EAF1B31B4333EE75D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D76728BF899DC869752E1AEF92F2522 /* Cocoa.framework */; };
+		3E2ECDFC62B33F044E1AF48EB320DAE1 /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC31759D90FFBB778349105CD32B82A0 /* TailRecursiveSink.swift */; };
+		3EE67AD4EF9BB7255F12A8E1ACF59F43 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D76728BF899DC869752E1AEF92F2522 /* Cocoa.framework */; };
+		3EE7A1AD2ACB8E5B50341976B1316CAB /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0081C0EB913B4A12C9BA7F9E2C44CA /* CombineLatest+arity.swift */; };
+		413C9E34B2F9D258BD62EDE945AEBE45 /* RxScrollViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674637809C1638D6E46627D0A7363E43 /* RxScrollViewDelegateProxy.swift */; };
+		420B2B089843D05295392FFE1944FFC5 /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCED313175C4FDCE4ABF2985910FD43 /* Sink.swift */; };
+		421A99241D4A19BC0384E070B6F733C6 /* NSObject+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEB61CDD7978740C1A32E03C8A96C40 /* NSObject+Rx.swift */; };
+		4243ABB4D6D5A1F0E3F004DD880FCC0B /* UIBindingObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5F9B539C916CEB13C073BD9B8706C9 /* UIBindingObserver.swift */; };
+		42656EE65DDFF8396FEC9E28CDD0F922 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477AECB674F89335ACC974874BAC99FC /* Logging.swift */; };
+		44A9E2D9BDB77A290A874AC9B82CA058 /* ConnectableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EAC6560D0E865FC286D0B2CEB21F8D /* ConnectableObservable.swift */; };
+		4532A8C74BD6D971D4ABCC991604D0B7 /* ImmediateScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3923EA7357FC6223BC856AAE0F07580 /* ImmediateScheduler.swift */; };
+		455E80A5EA99580469518024869EA1AA /* RxCLLocationManagerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1D85D88F45DA1940997764A3F22DA0 /* RxCLLocationManagerDelegateProxy.swift */; };
+		47C71957DC7BADC013C58987277C1BD2 /* ShareReplay1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784DCD30FFABD70154CB39E13ADC428B /* ShareReplay1.swift */; };
+		48EB43C260994DB39FF711D96FB30B66 /* ControlEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DD1AB167A06B315005919A9BD6E8B4 /* ControlEvent.swift */; };
+		48FDC28F367EE164320F7C40A5BBEF6A /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FED2EC4C912C80F8F0A4FE9E545CB4E /* SubjectType.swift */; };
+		491AEE4FE3195E5CA1225E6294EE1D43 /* RxTableViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC848B1D95281036D21CC324D052753 /* RxTableViewDelegateProxy.swift */; };
+		4A6886197AD7FBF1B3FE9A919B412C2A /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA440FABEECC06934002C5B7DFFD96C3 /* BehaviorSubject.swift */; };
+		4ADCF9F5D8C0D7D8D78504E013A3F8F8 /* UITableView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA9612F9925AA3168C6A101B4C99CEF /* UITableView+Rx.swift */; };
+		4BBFDC66B5D6EDBA302DFCCD0A31BFD5 /* Driver+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE379A21FCEBCEC0E0E426D9A123F760 /* Driver+Operators.swift */; };
+		4BCCA5EA84D6D228F84102A8C62BC93A /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA682272C2916EFCE819012AA8F6F4C6 /* PublishSubject.swift */; };
+		4CF423794EC5A22C04F574B184D00299 /* ObservableConvertibleType+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0298A8428E79167215D2B8D70D16A5 /* ObservableConvertibleType+Driver.swift */; };
+		4E0B27C110E6EBE3540BC9CDE16DAEBD /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0105A3A5AF33D1CF3973AD0CF4AEB9C /* InvocableScheduledItem.swift */; };
+		4E118E5BBB86F4E3D5BE4404D82BE6D0 /* ObservableConvertibleType+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0298A8428E79167215D2B8D70D16A5 /* ObservableConvertibleType+Driver.swift */; };
+		4E23CD6B7C23EABCF587E3A2E346290F /* RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E477EE3500BD6A016CE1951B989CF75 /* RxCocoa.swift */; };
+		4F2D991B08E329A0337FB73CACB68194 /* NSLayoutConstraint+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399E931BEE7F5E5F5E04BAA0FC0DE34 /* NSLayoutConstraint+Rx.swift */; };
+		4F30C3F0E32A967675B65D48BEAB63A4 /* RxCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 89361C46E5D991265A6D4AECA7F2EAC4 /* RxCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FD268B8698165B5E6A0F33480CBBC33 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C544817D76E71D828DB3AE0EE5DFA3 /* InfiniteSequence.swift */; };
+		503E3338DF4E754C7E55F6C3B1E3E077 /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B7AE23C229717D736C40F90B8D574 /* AnyObserver.swift */; };
+		51C2DEE2E38271654A307DB0A57826FB /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86FFCA66ED86F404880F6B796F87F05 /* Platform.Darwin.swift */; };
+		5282FD9C9A97C069805A7E22A42BC5A8 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E9E99E1790D8207298D944DDA5D4A2 /* VirtualTimeScheduler.swift */; };
+		536AE1D5281359DEF6F7890B09F1B40E /* Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283198B3A1BC9C9C64AF8776DF9D8602 /* Driver.swift */; };
+		53C9EC191E217693F417F3F3D5BD7E43 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAFF37D2CE77D76494B7F42ABF4792A /* Rx.swift */; };
+		541C9D6E1A995FF9AC9ADD3FB982BCE3 /* KVOObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE5313DC68E5A2FFE47DB9B6FC673E6 /* KVOObservable.swift */; };
+		548BFBF4A1720DBCC0CDA20A3FC5F98E /* Pods-RxGesture_OSX_Demo-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8614B5BCCE597A517451A65FDCCF091B /* Pods-RxGesture_OSX_Demo-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		54D5A7B71E1199F308A12D92BD355DD0 /* UITextView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD4E7DF61DAAA84A22AB05AD877367C /* UITextView+Rx.swift */; };
+		55803E192FDF33FACEB82F80810AD284 /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0105A3A5AF33D1CF3973AD0CF4AEB9C /* InvocableScheduledItem.swift */; };
+		55FD4EC3DFD48707D686FB0E30E9CFEB /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB5D2484879C5E0D0AC211D9FC603D5 /* CombineLatest.swift */; };
+		55FD53BACDCF756892618AE87B40E110 /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1541EFF54CE15FA4247A89DFB63268D8 /* String+Rx.swift */; };
+		566759A64E3D6143035478A562348AB4 /* SynchronizedSubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E104B9153F15585DEC6956D497ACD /* SynchronizedSubscribeType.swift */; };
+		569C76844EC991348E682B42B5153E23 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86FFCA66ED86F404880F6B796F87F05 /* Platform.Darwin.swift */; };
+		56FD49EF04E53934E3A49F07237ACAE7 /* Observable+StandardSequenceOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD6A6C23C63D4EB73064E6C68E20CD5 /* Observable+StandardSequenceOperators.swift */; };
+		57441D145F1BBDF326D2F35A2E722FEA /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41691D1578A4288F5D547260BF7422E4 /* DistinctUntilChanged.swift */; };
+		57A44A6F3687891BCF5CB0CDB1B1B7B7 /* KVORepresentable+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E7917F369F21F0188070F597CDE8E6 /* KVORepresentable+Swift.swift */; };
+		57E883ABEAA37C1D5A61A17EDF8C5CF6 /* DeallocObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4F910A4EF4840DF1A5FA245812BEB1 /* DeallocObservable.swift */; };
+		581AF6CF184D616CB20A4BF3484367C7 /* KVOObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5E833F61266E85C52B9AFA5BDA55F0 /* KVOObserver.swift */; };
+		58F145B976F3F9425E87313ECFD8E02E /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A847199C59581AE111ED00A7096043A /* Queue.swift */; };
+		593F579D1BAF6BE32C0C8EE70F88A84B /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE9731E7AB29C0A4F4994F544D31EC /* DisposeBase.swift */; };
+		5ACBDD58CF47ECD8AD16A8E21B38D22A /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A995AACF502C4037D6FBC4C6112ED3BB /* Sample.swift */; };
+		5B3561537F5610E105E39CD7552E1426 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19A8502B4392E2C35D5ECF8145E781DC /* Merge.swift */; };
+		5BAD48CCE78D0D04C2596297ED9F3F97 /* RxImagePickerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F748183552175B762FB45CE31A2F53FC /* RxImagePickerDelegateProxy.swift */; };
+		5BFEA69A0915F6918164977C108CBBAF /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A847199C59581AE111ED00A7096043A /* Queue.swift */; };
+		5C897B7691027D6EF6468F249FEF2833 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E085BA27253B4EFEDD426526E4A96A /* Bag.swift */; };
+		5CD5BCA415EF28EF307CECBA0621EAC6 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4122641759BCB149F3FCADD5C3268F7 /* Error.swift */; };
+		5DCBAB0AEE38AA2F3D5A38E87AAE9EDF /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB32E46DA8057A3A622F29F4500772A2 /* Scan.swift */; };
+		5ECA4DA302151ED29AF5DAD33DF54FA4 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E98F8FEECEC2DD9F966C9D3E8807071 /* Range.swift */; };
+		5F9E2936986466A91E3AA1E822C6D3F5 /* NSObject+Rx+KVORepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72024E9C45ED7ABA10282FBC2A8B6CC9 /* NSObject+Rx+KVORepresentable.swift */; };
+		60D58A4919924C9ED9BC875A2866FBDE /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F569847A7107D9276E4725C50D0916D /* PriorityQueue.swift */; };
+		60E0E6A55FB93D1F65E4691E05F2047B /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680753ED29B2B36844E7BF1D3EC725DE /* VirtualTimeConverterType.swift */; };
+		6147FC5841082B8D142AE6914FB00B7F /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226B5AC3BB6D95D9409C54D83CFBBDD4 /* BooleanDisposable.swift */; };
+		615ABC9784F0410A0AB3F458224F9374 /* ShareReplay1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784DCD30FFABD70154CB39E13ADC428B /* ShareReplay1.swift */; };
+		615B0141A00A2139932548F59332833A /* Variable+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B14A01C0088D795DF56061F4DA5C947 /* Variable+Driver.swift */; };
+		625F7B91B276D9AD6E32248D4F1F4861 /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60D78F33A072FBB5C97E5841B867C77 /* HistoricalScheduler.swift */; };
+		631A1DD20311EE54BC795DF915327298 /* _RX.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5384AAA357E269F58CCF248EF00C45 /* _RX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		656AF484ECD477CE254E68B0845BE284 /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A5CCFF7C755C16BD3B5DB4FFE1F88D /* MainScheduler.swift */; };
+		659676DA59F72833BBCCB9853A143C7E /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E085BA27253B4EFEDD426526E4A96A /* Bag.swift */; };
+		666EC55287F6C67AE52B6B460EAA059D /* UIImageView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5F0C9794F6E7E5EDE3E81BB3D21943 /* UIImageView+Rx.swift */; };
+		66E7C9EF14FDB3049AD6DBADD3D5F546 /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3A97DF6DC20E8FA7115AF427A1FDA3 /* ScheduledDisposable.swift */; };
+		6744289BF897F4D0525E1819B31C7CA9 /* Observable+Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1371EDFFD119B102C16B66F5769F97F0 /* Observable+Single.swift */; };
+		67CAC0F262FD2A9FCA59C6463798FCAF /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F569847A7107D9276E4725C50D0916D /* PriorityQueue.swift */; };
+		6852FC5243339B784056CB637BC1FEAC /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A10A251161E99CA06BFBA191386FB4 /* RetryWhen.swift */; };
+		68FDD0E090F8DA37A3283ABA5E5DEF50 /* CombineLatest+CollectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90193FA637C5E3C76DCF1888950DB2C /* CombineLatest+CollectionType.swift */; };
+		6956E7A76E55AB0986EE76E8CDF2AC47 /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DF800B19E074DBC494C3F9A24063 /* BinaryDisposable.swift */; };
+		6982B8E4C6FF27973BC4186FA1B03D23 /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449F0019DD1F3E76574EB8C06356C328 /* DelaySubscription.swift */; };
+		69AC08DF9FDE31998C7869EBAF62B3AF /* ControlProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70AF53C1EA75011D56334E4AB4C72E91 /* ControlProperty.swift */; };
+		6A0028F31D3A66050062328C /* TapConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0028F11D3A65960062328C /* TapConfig.swift */; };
+		6A0028F41D3A66070062328C /* TapConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0028F11D3A65960062328C /* TapConfig.swift */; };
+		6A2E2C219DFF6D32C16239EE310606E8 /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236983DA69E6A12F58775605239117DE /* RefCountDisposable.swift */; };
+		6AAF23825904D6DFC9229E6C7BD8CA4C /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09F8FD785663489A532E8A69164E9C /* SynchronizedUnsubscribeType.swift */; };
+		6ACDA50CF7E4AA489A05B943886D1329 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C544817D76E71D828DB3AE0EE5DFA3 /* InfiniteSequence.swift */; };
+		6B702CBA3187CA6D991CBE76351837FD /* Observable+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806CC77B1040592A24B4F57B756C9AA /* Observable+Time.swift */; };
+		6B81B26818BFF79D9DE0909B20812BE6 /* Pods-RxGesture_iOS_Demo-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FBC2B3604E156C2B39FB243BDBF5FBDC /* Pods-RxGesture_iOS_Demo-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6C8881718CC15265D09C41CBB10B7E9E /* Driver+Operators+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71AFAD963301C46BC7BC87E5B3D2F396 /* Driver+Operators+arity.swift */; };
+		6CAB49D89624A04E4152A06D8E5AC124 /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32333103781E0D7296DE45160EFFCF8A /* LockOwnerType.swift */; };
+		6D2AD61B12BFF5101ACA654F7586EFBD /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF5397CE64E09EB5C37D737FA40398 /* RecursiveScheduler.swift */; };
+		6F1701065113278B4F9EA93F2C4D30AB /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032DD707905DA8D3C57277EF878F3240 /* Take.swift */; };
+		6FC7A3AACED3A13E19B113FBFFE5F6A6 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0047D7C07D4E7168D66A6B195B20AF58 /* ConcurrentDispatchQueueScheduler.swift */; };
+		6FD602910C6A4CCF48277C86A835C39E /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD15299911C10004D6C338D4883BEA6 /* ImmediateSchedulerType.swift */; };
+		70395B0C308DEC6A90B53EDF20802995 /* DispatchQueueSchedulerQOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245AC5100739C5A8E44FBFE74CCCCC12 /* DispatchQueueSchedulerQOS.swift */; };
+		703A91CA61086D71F395EB4300699E18 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19A8502B4392E2C35D5ECF8145E781DC /* Merge.swift */; };
+		70767CE5090AA6DBA27615A97E5975B2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D76728BF899DC869752E1AEF92F2522 /* Cocoa.framework */; };
+		70E1CCCB0F08BF258F53C425F111D784 /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25308CFE7CECE3CF7E9AC0EBBD33AF9 /* Catch.swift */; };
+		71BC036D660D42931AC03ABF46519321 /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226B5AC3BB6D95D9409C54D83CFBBDD4 /* BooleanDisposable.swift */; };
+		721A84CDA8546C0571A414907F59A60C /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA6793E8440943D0A3CE5EC20DCC7FC /* Window.swift */; };
+		72C524E7B71E56E69737978A30762BD0 /* Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A0F993C4C6D6C90DB6204A41E10A910E /* Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m */; };
+		72D0FD90034EB33EA0C92656D7074D46 /* RotateConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B938000B6A988DBB740EE2ED9F411571 /* RotateConfig.swift */; };
+		732C1BA4FEAEBF02986DD3EE64224F80 /* NSNotificationCenter+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777BF9DD554FFC95F2DFA576184620D8 /* NSNotificationCenter+Rx.swift */; };
+		73F6711DED2B6CDFA88C34BBB7283730 /* UISwitch+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C4B9D95966A3DD638408DD2AC9A1C1 /* UISwitch+Rx.swift */; };
+		7418514157E5C688CE763A5F254CF413 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A995AACF502C4037D6FBC4C6112ED3BB /* Sample.swift */; };
+		7434BE3361F7A52BAE1FC831D881C933 /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B7AE23C229717D736C40F90B8D574 /* AnyObserver.swift */; };
+		74B6F38577B25B297F2010325DC77DD3 /* Observable+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B8FB88CC735C3CC651A2DDAA219E5 /* Observable+Concurrency.swift */; };
+		74F5E7BE653FC92CDD229EC32CBCDFE9 /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6AB6AEB9265AFCBF6B63FE10D75B45 /* ReplaySubject.swift */; };
+		750B5432B0FF3138009F3EEA57AFE84E /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6D897F503A3460A4E195622BACB277 /* Debug.swift */; };
+		752964FCFB788000B79D21627D4D737E /* CLLocationManager+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC1F877E92090E34F5CE2FB79F4629D /* CLLocationManager+Rx.swift */; };
+		758C1D78FBE53E84387DB6ADD0076CEF /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA6B4837F238135EDBB1FD219AC21E8 /* DisposeBag.swift */; };
+		75DCFE5F338EA7396929204D17363C5F /* _RXObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = CB48DAD7D5163991153C05BD30040B6D /* _RXObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75E7B15E4542BBAB1CFDDDBD6EA1780A /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF5397CE64E09EB5C37D737FA40398 /* RecursiveScheduler.swift */; };
+		772264D999738121516654B4232C27CA /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E745319BCA81A3F171ED2C1DF23643 /* Zip.swift */; };
+		7783C8B43B0F83A3E122DF1748EC8CAB /* RotateConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B938000B6A988DBB740EE2ED9F411571 /* RotateConfig.swift */; };
+		7847BFC1F539128C32E132CB47172B80 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD670E6BA419147639CA62FC8C3CEDA5 /* Platform.Linux.swift */; };
+		789C95EFBA949A2C03982A2E9D62E0DD /* UITextField+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDEF5835D5C10A026F090259385CC21 /* UITextField+Rx.swift */; };
+		7908C1A8D99504533AC23866832E9706 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54EEB7F3D9B9D4D2E5708405A57F65E /* TakeUntil.swift */; };
+		79AB7F257D1569817E550D4098C2E58B /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B83162A671B863092C509640455BB1 /* ToArray.swift */; };
+		79F67FB9CB9E17F8CBF312FA0084EAB2 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02736A0824ED21A5F170A055AAC18B5E /* Do.swift */; };
+		7A6AB5F92240D1411B8C16AA3601EC2D /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60D78F33A072FBB5C97E5841B867C77 /* HistoricalScheduler.swift */; };
+		7B78DDBD2013D33F60F929243F25B565 /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573193BEB3DE9B1053800EFB15956A04 /* SchedulerServices+Emulation.swift */; };
+		7CE43A2B274B3A1C65CA161F632448B1 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371997EFA02B3641F6F5DCA3462F231D /* InvocableType.swift */; };
+		7D3EFAC4F3A7F0FFD1AF360CCFE9CD71 /* ControlProperty+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDA9865788B870D2E0C9631A55AD2FC /* ControlProperty+Driver.swift */; };
+		7D929FFFFBCE37A90FDFAEDF52FBF97E /* Zip+CollectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D04517DD6AD2781E4CB927E673828D5 /* Zip+CollectionType.swift */; };
+		7E1DAD3A8BF695335D0FCEC77C7B2629 /* ControlEvent+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E058D4EBE0ECDD108B8578F0C62D285A /* ControlEvent+Driver.swift */; };
+		7E412D4C2839AA78A37DC16806611918 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0047D7C07D4E7168D66A6B195B20AF58 /* ConcurrentDispatchQueueScheduler.swift */; };
+		7E53E34B09E745150E50C6A324601EB6 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7731A4628E596D95ACD0AFE6EEBBA43 /* Filter.swift */; };
+		815412E715BE08871E4C5ABC97006596 /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBB3142C058BFF8F0B79E20C43D86F8 /* SynchronizedDisposeType.swift */; };
+		83C2F4F5EF675EAC0897B942201FF004 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0278F3FA193A3C83B14B2E3F9ED87E2F /* ItemEvents.swift */; };
+		83E43C0E90CB742D1536BB8DA28FC055 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3923CF81B57F0AB60F4DE73C980321DD /* Event.swift */; };
+		83E49E67B149F9FB070BFAC545DEC15A /* Observable+StandardSequenceOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD6A6C23C63D4EB73064E6C68E20CD5 /* Observable+StandardSequenceOperators.swift */; };
+		847D340E4481EB953B56E987A8863B62 /* Driver+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A12623F1AB0752800B1DB10DF0417CF /* Driver+Subscription.swift */; };
+		8526D54EBF04F2654F48E763F88A8142 /* UIView+RxGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9DCD3DE6178587C27AF8D985383E08 /* UIView+RxGesture.swift */; };
+		85BEA7D91944470D6D27E8F8AFD5DC33 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE492C558DEBA31064661917BC71BE2 /* CurrentThreadScheduler.swift */; };
+		860D3C64CC7EDA6718F7158ED0F613DB /* UIView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF76949F9A826C7D066D20516A6268E /* UIView+Rx.swift */; };
+		87106C3E8834791259A7E930EF519CD2 /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2B40CC335CF4F90488701FB34D321D /* ConnectableObservableType.swift */; };
+		8785D32B23307F4B79618A5F7856F44F /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1541EFF54CE15FA4247A89DFB63268D8 /* String+Rx.swift */; };
+		87DD8E5189D29C2A58ADF3FB7B5B0FBA /* ShareReplay1WhileConnected.swift in Sources */ = {isa = PBXBuildFile; fileRef = E145F810DEFF07BCE812538BFA651708 /* ShareReplay1WhileConnected.swift */; };
+		88598E8F88F0DAC9F2DA4B493925178E /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64491ABA744A4BD99C4CB1D733B5DA3 /* RxMutableBox.swift */; };
+		88FC4A07660873918F076FF438E24176 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B594A1B0AF0D78EE827EB80F48CFEDDA /* SchedulerType.swift */; };
+		8987DC4DFACCA1F78A94D60F1EDFC99B /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666CEAE2C63819EF5FAC680D6243A456 /* Sequence.swift */; };
+		89BA35490BB928E75A9CC8E7A2FA3DDA /* SynchronizedSubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E104B9153F15585DEC6956D497ACD /* SynchronizedSubscribeType.swift */; };
+		8A01F5D8032F07A5A0D80DCEA17D7282 /* PanConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 383E8395E05602750FB92C87A2FDEB92 /* PanConfig.swift */; };
+		8AE5D75670141C6CD6BCBD346D5587AF /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCED313175C4FDCE4ABF2985910FD43 /* Sink.swift */; };
+		8D3999B3B1E916D957A5C779A5EBB60E /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F0A2FEE585A9018680D5769208A755 /* Concat.swift */; };
+		8D3EEF1A053E268995FD7ED5169F02B0 /* Observable+Multiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94D6C7DD2DDCFDF47973632D61DB036 /* Observable+Multiple.swift */; };
+		8D75B23AA0082EE3BE5054DF283818F3 /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC31759D90FFBB778349105CD32B82A0 /* TailRecursiveSink.swift */; };
+		8DA8A901EE6CDF0AF1D59CC4EEC1F3C4 /* UIRefreshControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E699138D97A7B8FB51A1169458CC5B /* UIRefreshControl+Rx.swift */; };
+		8E2DE5024F9792C19792D92B8B1D985D /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573193BEB3DE9B1053800EFB15956A04 /* SchedulerServices+Emulation.swift */; };
+		8E4DD36D597C752EBB6051DF7A6258A2 /* _RXDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4249BCB52EA315CF45C8AF750220C3 /* _RXDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8E73D62412624AB799DE8F75CC24F0F9 /* UISearchBar+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0BF625CE8A09C228BDA4F907267DA2 /* UISearchBar+Rx.swift */; };
+		8E7CDAC755EB5A725153296B2E243630 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E8B074971AF38C0412AE173DB4552D /* Foundation.framework */; };
+		8E9D487DFEA8015CA9E7123698C10196 /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B57D8DB71BDAB80D01EB772BB8B51EC /* ObserveOn.swift */; };
+		8F5E62777148745FAFCD9848F2216462 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A47B3D1B773D68299EDABB9A4D54E96 /* Variable.swift */; };
+		8FE9F9B1EC3C5A7D2D6CDAA2C4BA9BAE /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880EC46B2EA4171F124091B6A8EEC9BE /* Throttle.swift */; };
+		90379C4D111C3BB8834CC117AD072DE2 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34A5CB470BDF4610D116B4C6E6310CC /* Using.swift */; };
+		90FC859F6BEF7CA9F25A3F57BEF925A5 /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = B746BEBFCD9CFA793E10E15D5E7B47D4 /* Just.swift */; };
+		91721397EC011682D479904C93C12753 /* KVOObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5E833F61266E85C52B9AFA5BDA55F0 /* KVOObserver.swift */; };
+		922DA1B8B35C278C5E7E06E5EC5D9D74 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F12CA77D6F2C4B36E0E751A89004250 /* RxCocoa.framework */; };
+		92A2FEAAF18E42ADF6CC190BFA27217D /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD670E6BA419147639CA62FC8C3CEDA5 /* Platform.Linux.swift */; };
+		932A608D68C76DBCD3887C0428352870 /* Observable+Aggregate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B69664E4718AC7434121C115138625 /* Observable+Aggregate.swift */; };
+		93CBC8B4B0B4A92CC028405BADDC7BB7 /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B3B751B0C5F626CB6E8FCE543FF5CF5 /* NopDisposable.swift */; };
+		94253F9E40DD9BBE9F3C9329447B4968 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB5D2484879C5E0D0AC211D9FC603D5 /* CombineLatest.swift */; };
+		9505DB71A910A7EA4A2BC2F348605F5A /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F12CA77D6F2C4B36E0E751A89004250 /* RxCocoa.framework */; };
+		9594E7B489E20FA0CE16209AA0D9A33B /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E9E99E1790D8207298D944DDA5D4A2 /* VirtualTimeScheduler.swift */; };
+		974A7B9743248803127142B96776A1CF /* RefCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5C6A9BAE45FFA2C75DC00EC9F9430F /* RefCount.swift */; };
+		976CED50E8A41F564ABC9D9722A9B749 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E8B074971AF38C0412AE173DB4552D /* Foundation.framework */; };
+		9786556AA0483D04DD189DA66A8BB80C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90F97FBA1E50C1F43EAF8F3FAABD06AB /* RxSwift.framework */; };
+		97C61F2EABC0E0556306C355CAF9A9DF /* Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FD1A57E1C3EFB8080B64032CEBA6EEBA /* Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99275884D21412F97109A8169AAC77F4 /* StableCompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A2FE6EDBAF67DE1651CFA7C30C0FA9 /* StableCompositeDisposable.swift */; };
+		99B67115B280334F9D6E4561C6A2B9B1 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C862CF3BD7290855D8AD7565CD8E2666 /* Errors.swift */; };
+		9A67BEAAD395C1FAB9421B85C177D655 /* SectionedViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3804ADE6554A61F56E0FCD797E6D3084 /* SectionedViewDataSourceType.swift */; };
+		9A72425633B1074724BE4AD9E253486F /* ControlTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A3310CDED6F0B1AC6B42A981CC578B /* ControlTarget.swift */; };
+		9ADA5122804C363890866E9689DC09EB /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E010F7B88BB02E629463A73BA403E1 /* Disposable.swift */; };
+		9B35043F7EA722855C342069EA69F80C /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC278E77933E0D1F364DBD2B0A24180 /* ElementAt.swift */; };
+		9B9B0018B167196825E5FC64DF2C60D9 /* NAryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714C5305FFAFC2F0793D969801E49179 /* NAryDisposable.swift */; };
+		9C03589B9228FF4EBFA9A3F7C7453EBC /* ConnectableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EAC6560D0E865FC286D0B2CEB21F8D /* ConnectableObservable.swift */; };
+		9C6F3D50FF5622B23E76113A13182DB2 /* Observable+Aggregate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B69664E4718AC7434121C115138625 /* Observable+Aggregate.swift */; };
+		9DDCA6731F75967C99C394CD687BA328 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477AECB674F89335ACC974874BAC99FC /* Logging.swift */; };
+		9EC42C15F58BCE37BC88E12D6733EF4B /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBB3142C058BFF8F0B79E20C43D86F8 /* SynchronizedDisposeType.swift */; };
+		9EFC8B35852B90A6EC3A9D47486CA105 /* RxCollectionViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935D94469ED0B54EACC3A4C0F12B4646 /* RxCollectionViewDataSourceType.swift */; };
+		9F217F9C4E260A51EC69B826D1ECAD47 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02736A0824ED21A5F170A055AAC18B5E /* Do.swift */; };
+		9F22B19D087C06C030D8F2540356AA99 /* ObserveOnSerialDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9688474E44B841F6129B4FAFFB2C565 /* ObserveOnSerialDispatchQueue.swift */; };
+		9FE76B6763DDF6DDE5A227F3FAE42324 /* _RXObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CD8DFA3BDA378BDC5FF885379349130 /* _RXObjCRuntime.m */; };
+		A03494739582FEBB17DA79D2920E1F7A /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032DD707905DA8D3C57277EF878F3240 /* Take.swift */; };
+		A07E4C0953ACB36A5DA675ABEDA61BB8 /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CDE42D609590B6AA8AAD038BF20E21 /* TakeWhile.swift */; };
+		A0F6D25550D0AB1122728E0E202E9B2F /* NSGestureRecognizer+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA5E789256C909EFAB76C6238E9F905 /* NSGestureRecognizer+Rx.swift */; };
+		A138EAA2EF4367C0E438246F137F7FF8 /* CombineLatest+CollectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90193FA637C5E3C76DCF1888950DB2C /* CombineLatest+CollectionType.swift */; };
+		A1435F6083BF431922428FD10EC7A363 /* _RXDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 49FBEB4800AA72C5B24F339E2CE4492A /* _RXDelegateProxy.m */; };
+		A1558AC0EC6057A3B2E5C0A902FC1623 /* SectionedViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3804ADE6554A61F56E0FCD797E6D3084 /* SectionedViewDataSourceType.swift */; };
+		A251D2B4AEC83C9A367126EC5FBD3154 /* _RXKVOObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF27BBCB2AAD5C679581C38EE2DC185 /* _RXKVOObserver.m */; };
+		A411B27CFFCA6B4EA5F4A46033C005A5 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B594A1B0AF0D78EE827EB80F48CFEDDA /* SchedulerType.swift */; };
+		A4FE2267F0D28CB4EDFF93E2BEA9E8B6 /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E745319BCA81A3F171ED2C1DF23643 /* Zip.swift */; };
+		A54A1ECD706A5EA99BE7D81EAA32A26F /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867FB6D9CD5ADD06727AA1E89197078D /* ObservableConvertibleType.swift */; };
+		A5867CFCE263A489500E497E982C98B3 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63811859DE646A04ED30107BC30950A /* Multicast.swift */; };
+		A58ACD233E056D2610BCF047FC636DD1 /* NSURLSession+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5079F022D850EE97985FE670AE654D3 /* NSURLSession+Rx.swift */; };
+		A653AC721AB76BD247BD21ACB54FC4E1 /* _RX.m in Sources */ = {isa = PBXBuildFile; fileRef = 26AAE4981F2B2A0B345D49C6FFF3F191 /* _RX.m */; };
+		A6985271C67D3D39671F6594CC636975 /* UIStepper+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59638383E4045E9D58DD49A2FAD59AB2 /* UIStepper+Rx.swift */; };
+		A741711B1571F9AEDC76DF57CDCC049D /* DelegateProxyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12DB9FC05ECEBD079763E18E22438A0 /* DelegateProxyType.swift */; };
+		A7F78203B95EAC361DD6C18C24D9C6EA /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16B90AA9D152514C8ADF7451C1E90A4 /* Generate.swift */; };
+		A80F223FA8DE3EFF2B59F5356E114EBD /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236983DA69E6A12F58775605239117DE /* RefCountDisposable.swift */; };
+		A870750758D17331ABB8C0A6FBEE9183 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B26A5D41DBB998BC91E988B0B68FFF /* Switch.swift */; };
+		A8D37F4EA054BE484E3BB6DC1A471493 /* NSView+RxGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754393E014D5DDCFD533E33A02544594 /* NSView+RxGesture.swift */; };
+		AA16F216C37B4D26B2AEBA5318F20F2B /* Pods-RxGesture_iOS_Demo-RxSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E592BE42F6C322EF48759A3D652B83BA /* Pods-RxGesture_iOS_Demo-RxSwift-dummy.m */; };
+		AA5369D0171DDDBBE6116FCB66834C5D /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1791E2917EF6FCE255F4894FA8AD /* ObservableType.swift */; };
+		AB11A18FBAC250B26EE7C7A08E3B8813 /* AnonymousInvocable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8FE7D88F5AF65F3E6D57C39B12F30 /* AnonymousInvocable.swift */; };
+		ABB75716FC955FDA06FCD29DE6F32178 /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0B8B080F1E6B923BEFBBF2DC5B11C /* AddRef.swift */; };
+		AC00F08A8CDC8D49C2A4DF634C4AA16E /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87E53818AF138ACF5D61B3D7D6E5274 /* Skip.swift */; };
+		AC8E5C01404D499F26CD4C999E341E12 /* KVORepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8C262F7B62C28B263F49AACFDFAB2D /* KVORepresentable.swift */; };
+		AD4ED07FD9EA0B454D9798F141F5CE97 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3923CF81B57F0AB60F4DE73C980321DD /* Event.swift */; };
+		ADC23C0C5CA9D89EC7970AEA31E22133 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0905B95004BC92DB93247A62B00B3165 /* Map.swift */; };
+		ADD429CB6F5F9DE75256086A939119B1 /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522CD8F0D5EA4DD356A6C34B68879AB /* WithLatestFrom.swift */; };
+		AE5FA788DE0D4E7D6D60BA1CEDEEFB62 /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0B8B080F1E6B923BEFBBF2DC5B11C /* AddRef.swift */; };
+		AF308452C9E3E4F62252D19FBD918CA7 /* RxTextStorageDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1DCEC4B3D1DAFFC879A8BAB2E0B13C /* RxTextStorageDelegateProxy.swift */; };
+		AF73F748061BE56ED8FDF3F99D0C0803 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EEA13950D3C7E26EA2C570F80B66C2 /* CompositeDisposable.swift */; };
+		AF895FF485271D550E4D064A84FB2619 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686CEFDB56AF5DFB18118006274FA02 /* TakeLast.swift */; };
+		B03014AE13A5E078B02A052A0FBE9A20 /* Observable+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806CC77B1040592A24B4F57B756C9AA /* Observable+Time.swift */; };
+		B0A9FD2263DA835993FD907E4B4CE2C3 /* ObserveOnSerialDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9688474E44B841F6129B4FAFFB2C565 /* ObserveOnSerialDispatchQueue.swift */; };
+		B30D924AB6FBA8B2DCAC4FC1495CB45F /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DCA1F1EC467C456DE2F6B57B5C35A6 /* Timer.swift */; };
+		B32070E942F1B441075C288B6D0ED075 /* KVORepresentable+CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54133C9D54D6BD5ED81DAE23B47861CA /* KVORepresentable+CoreGraphics.swift */; };
+		B3A94B8B6CFF3BB21B54E37E9A3CC829 /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A5CCFF7C755C16BD3B5DB4FFE1F88D /* MainScheduler.swift */; };
+		B5E007C19DC437B74F3B459606D3B040 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D1EB659125EA3969D59014B9F4E1A4 /* Producer.swift */; };
+		B6DFC690E7D0B1E5CADCFC3D7483685E /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A938D2640AAB94C102006232D3177B /* Timeout.swift */; };
+		B77B250A5C4091D9437711ACFFE1A60B /* RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E477EE3500BD6A016CE1951B989CF75 /* RxCocoa.swift */; };
+		B8E890AC72A2B515423B0873EBA7497B /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F618BDF7BC2AC6CC2A49F4069E5944 /* ConcurrentMainScheduler.swift */; };
+		B8FD0CAA10337CBD9FC73B16905717B6 /* UIDatePicker+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA173D102727E0176EED982ADA11269 /* UIDatePicker+Rx.swift */; };
+		B93E360837BF6049E6ADBCB496DD486E /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449F0019DD1F3E76574EB8C06356C328 /* DelaySubscription.swift */; };
+		BA8B75DCD8B33C4AD231FA051BF3EFC7 /* NSNotificationCenter+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777BF9DD554FFC95F2DFA576184620D8 /* NSNotificationCenter+Rx.swift */; };
+		BAF807493CB41AC83E6E5BF2D65CA107 /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB4F5995EE9165EFF01A1B67E31329 /* AnonymousObserver.swift */; };
+		BB34D4B1C2FA534E510E5A6F93EC78C5 /* Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B8393E60BACCB4386FBDC6A62A9FA561 /* Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC48F2F74FDE1124DE6CA9C516A65F1E /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90F97FBA1E50C1F43EAF8F3FAABD06AB /* RxSwift.framework */; };
+		BC99BB8FACD40E788CCAA7BDFBC77498 /* Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 40731FA149D0C969EF2ACC2B814AAA39 /* Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m */; };
+		BCC627EFA42BCBDD8FC0B3721D139E61 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EEA13950D3C7E26EA2C570F80B66C2 /* CompositeDisposable.swift */; };
+		BCDAA38E7E8D4116EA76D257BC319C4D /* Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283198B3A1BC9C9C64AF8776DF9D8602 /* Driver.swift */; };
+		BD376A3A84020AEE9C9152B28EC0E881 /* RxCollectionViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E30F06ECF68CB0C48EA50C7EE7B2433 /* RxCollectionViewDataSourceProxy.swift */; };
+		BD94DC753DE37948A6725AFEB246FC78 /* UIActivityIndicatorView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DB01547F7219DFA5AFF3C2A27DC685 /* UIActivityIndicatorView+Rx.swift */; };
+		BDDF748143E479CF6EABE05041F7B6F2 /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23025D7CBEA011BDDB9A5ECF666C1E8 /* SubscribeOn.swift */; };
+		BEE7FA81B3281D16D65348F06A05E393 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E8B074971AF38C0412AE173DB4552D /* Foundation.framework */; };
+		BEF4A476C5C6C876B27C5F88A81B5043 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34A5CB470BDF4610D116B4C6E6310CC /* Using.swift */; };
+		BF180276153CFFF40164206E6A3BEDFE /* NSLayoutConstraint+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399E931BEE7F5E5F5E04BAA0FC0DE34 /* NSLayoutConstraint+Rx.swift */; };
+		BF46C30F6DA5B7E88423642828CEEDF3 /* UIGestureRecognizer+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3CECCCF5890CBE65780B3C8D44E2B1 /* UIGestureRecognizer+Rx.swift */; };
+		BFC2B5254C88254A58C95900FBA83AA3 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3871A7C8372F1322E306860D1430882B /* Cancelable.swift */; };
+		BFCDB1F0CB2317AA6C5C494CE54FE8AA /* KVORepresentable+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E7917F369F21F0188070F597CDE8E6 /* KVORepresentable+Swift.swift */; };
+		C04B8E1CB28327C6E3329D5C505F1E5F /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F0A2FEE585A9018680D5769208A755 /* Concat.swift */; };
+		C0A6FE769DB8A583B4AB4F853DCACCB8 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC278E77933E0D1F364DBD2B0A24180 /* ElementAt.swift */; };
+		C2C7F0554D20A58F6D5E3657640E6745 /* ControlEvent+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E058D4EBE0ECDD108B8578F0C62D285A /* ControlEvent+Driver.swift */; };
+		C317D014A7DBD70F5AB21D95B1C1DE85 /* AnonymousObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFDC7869C929289A9CD3A92B63C692D1 /* AnonymousObservable.swift */; };
+		C4C47BAFEE1709C11AB5145DCF02D960 /* RxTableViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5DCE08601B273DE0CF84D2AC1CA7D /* RxTableViewDataSourceProxy.swift */; };
+		C4C8C36FB51CB1A5BEED5AAF41603DE2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D76728BF899DC869752E1AEF92F2522 /* Cocoa.framework */; };
+		C4E0857D9EDB53394B79170F060B50DD /* UIBindingObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5F9B539C916CEB13C073BD9B8706C9 /* UIBindingObserver.swift */; };
+		C6913A7E9C0C2474F28A914401538F1E /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419FD89DFCF42A6ADFE86D2D84B0EA46 /* ScheduledItem.swift */; };
+		C6B15BFB809D0286742C1447591A61D9 /* Observable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDB236E3E70B35781D525D0318E5BB7 /* Observable+Extensions.swift */; };
+		C7173C062C939B53E256CEE89C8C85FA /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA208E4396D571B3FF2C758E089F3C95 /* Observable.swift */; };
+		C72E3C80BC9C48E5640A4CCEF40949A5 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA208E4396D571B3FF2C758E089F3C95 /* Observable.swift */; };
+		C81E9FE86F69EE1D3FAF2AC827103164 /* UIImagePickerController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E17907AF176E8F017DBA35163551D37 /* UIImagePickerController+Rx.swift */; };
+		CA139E952DF537781D766699B18CF101 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E8B074971AF38C0412AE173DB4552D /* Foundation.framework */; };
+		CADA73E1D18C4B1507FA15CE4A973324 /* ControlTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A3310CDED6F0B1AC6B42A981CC578B /* ControlTarget.swift */; };
+		CB761ED25DD8E01E6FE70D51365524DB /* Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D1541DD57D56EB09CEF071E8D1144E48 /* Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBA8DBF45CDA4CFC978E23AB26A807E8 /* NSControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95792EE983BD8CEAA248950D147179F7 /* NSControl+Rx.swift */; };
+		CCE36FB9BC39FC2DA56F7ADB0C6B04D5 /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036645378416B45CDB8CE10B07BE2213 /* SerialDispatchQueueScheduler.swift */; };
+		CD7301609168DEDFC3736C07BA0881B1 /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0C7DD780E181D0F5EB28D77EDB199C /* SerialDisposable.swift */; };
+		CDBD80EB63A3482BF30B876938782D2C /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680753ED29B2B36844E7BF1D3EC725DE /* VirtualTimeConverterType.swift */; };
+		CDF9FEDEA4D51C517D572E46FBC8621C /* Observable+Multiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94D6C7DD2DDCFDF47973632D61DB036 /* Observable+Multiple.swift */; };
+		CE245DA8E68C8D112CEF7E56A751CD90 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920C57CA223DED99EA2B9BF7416E8664 /* Amb.swift */; };
+		CE528D85B9B645900D89164F2722CFF0 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC81FC6ADF84CBF9D24DF18F08820B7 /* AnonymousDisposable.swift */; };
+		CF029F863E85E7C03591D4210989B647 /* Observable+Bind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2488AC35E99BBB5538B1BD95F7655E94 /* Observable+Bind.swift */; };
+		CFCF19080BB274D8EEF1B5A844B36F5E /* Observable+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F86A42574378E3C19BB20A1D4F6EE1 /* Observable+Debug.swift */; };
+		D14C2BC5CCDB880C6B15F4858C458EB1 /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B20F6146FF7DCA5A308859C677FAA81 /* UIControl+Rx.swift */; };
+		D1F1D0390E73502FE5C22246171BE72B /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADD86DB658ADA7B22F4A9E9D1DA25A8 /* SynchronizedOnType.swift */; };
+		D1FE0E16B1F05DFE7771055D52939287 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3426C8436E0E44F1E70A1F7BC6D4BF63 /* Reduce.swift */; };
+		D2CB38767A2E8CD22E0C3F424ACDC178 /* CLLocationManager+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC1F877E92090E34F5CE2FB79F4629D /* CLLocationManager+Rx.swift */; };
+		D4471926F81D20E92AAC8F5D7966020C /* Variable+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B14A01C0088D795DF56061F4DA5C947 /* Variable+Driver.swift */; };
+		D56B102D752D618E23E784BAC7AFAA95 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3871A7C8372F1322E306860D1430882B /* Cancelable.swift */; };
+		D5F0C6BCB89A7D95ADDDBE8D79996573 /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A0C86A2E540C585BD9EED8227FC082 /* SkipUntil.swift */; };
+		D6B1F7F217F77E9186E76925C6CE6D3E /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE492C558DEBA31064661917BC71BE2 /* CurrentThreadScheduler.swift */; };
+		D6EDDE62751FFA62ED72081E39D6F19F /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94C88848C57B60ABE5E9867B1942078 /* SingleAsync.swift */; };
+		D7500103A9FAA223279359D5F701B1CA /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB32E46DA8057A3A622F29F4500772A2 /* Scan.swift */; };
+		D85E2176535BD6BEB9DC135A7F8B1C18 /* KVOObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE5313DC68E5A2FFE47DB9B6FC673E6 /* KVOObservable.swift */; };
+		D8AB8DFEA14F6A474AAD67911ED5F9AD /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D368C07F4793B141BBE46A5B8453B177 /* ObserverBase.swift */; };
+		D8B0D36D7985B7BAAA81FB480AE40EB1 /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADD86DB658ADA7B22F4A9E9D1DA25A8 /* SynchronizedOnType.swift */; };
+		D92B1754DDCAEF92566DAC3592014D73 /* NSObject+Rx+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFDBBFF08F74F9511DF21F873EABE86 /* NSObject+Rx+RawRepresentable.swift */; };
+		D9B6E88A21A5218B4346387AFDB83F3C /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713CD0C782C89D147C113A835FA5BD81 /* Zip+arity.swift */; };
+		DA600661558FFEB04BB1DA6E56D7BA9A /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42922C460C6B4921C335F9A0AB78966B /* AsyncLock.swift */; };
+		DAC73301778EBDD3A376AB81B1706375 /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C8BBEADC28B99A09E31C0BC5FE57FD /* OperationQueueScheduler.swift */; };
+		DCA27732462FA9070AE710D9A361ADA0 /* PanConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 383E8395E05602750FB92C87A2FDEB92 /* PanConfig.swift */; };
+		DCBA1326E666BBBBE25A8762C87B5C3A /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA682272C2916EFCE819012AA8F6F4C6 /* PublishSubject.swift */; };
+		DD3230BF944AB4C33C9399E620557C07 /* _RXKVOObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = EB39ED08E4C74181954C6B42D69F7FB7 /* _RXKVOObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DDBA8228316C11F620BEC183CE24EBCC /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522CD8F0D5EA4DD356A6C34B68879AB /* WithLatestFrom.swift */; };
+		DDF30573D7664E73624011D0DAD860C5 /* Driver+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE379A21FCEBCEC0E0E426D9A123F760 /* Driver+Operators.swift */; };
+		DEBACD931A5946D126B0215F2E5490E9 /* ShareReplay1WhileConnected.swift in Sources */ = {isa = PBXBuildFile; fileRef = E145F810DEFF07BCE812538BFA651708 /* ShareReplay1WhileConnected.swift */; };
+		DF0B0172701409E57A6201CA8FBF0574 /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0C7DD780E181D0F5EB28D77EDB199C /* SerialDisposable.swift */; };
+		DF644BC19728B14C164A989F9C370CDC /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBAC0789FA5CD3B9A97859B6633DD22 /* Buffer.swift */; };
+		DFF7AC2C01AE58822F964F3F439067AA /* UIButton+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83425313765F7ED109DC81D7BADC7B5A /* UIButton+Rx.swift */; };
+		E04FB4107DD3A5DCF1062A8E82ACA4F3 /* ControlProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70AF53C1EA75011D56334E4AB4C72E91 /* ControlProperty.swift */; };
+		E1D340DC7B6235125C738489439509C4 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54EEB7F3D9B9D4D2E5708405A57F65E /* TakeUntil.swift */; };
+		E2EB128A6BB718BA85611E62366C103B /* _RXObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = CB48DAD7D5163991153C05BD30040B6D /* _RXObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E3399B666DD32E780F2CB38A337B38CD /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D1EB659125EA3969D59014B9F4E1A4 /* Producer.swift */; };
+		E3AA96F7AED9BA93194DC007ECEF5253 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C862CF3BD7290855D8AD7565CD8E2666 /* Errors.swift */; };
+		E3C9982D23DD01F4E2153362830857AF /* RxCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 89361C46E5D991265A6D4AECA7F2EAC4 /* RxCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E3E5A164068D5B2AAA03B81990810232 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E98F8FEECEC2DD9F966C9D3E8807071 /* Range.swift */; };
+		E49783BB78FFE662360F74DB16C026FC /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80464EA0B50C6A06A9C5061AA0E72B6E /* Deferred.swift */; };
+		E4DFD6E97EE78AF7AA8BA84E20C6523F /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B83162A671B863092C509640455BB1 /* ToArray.swift */; };
+		E4F716E7B90B006A0A58F63CC6266D4D /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD15299911C10004D6C338D4883BEA6 /* ImmediateSchedulerType.swift */; };
+		E5748D29F9391596CDD479CA089F4E1B /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE9731E7AB29C0A4F4994F544D31EC /* DisposeBase.swift */; };
+		E57C18EEA2C6EAAAFC661CC36A08359C /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A0C86A2E540C585BD9EED8227FC082 /* SkipUntil.swift */; };
+		E5AAEEC20D987248D63ADAEC556054C8 /* RxTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4BF2809DFC533229426FC2B1D4AF91 /* RxTarget.swift */; };
+		E60ED422014F151D85A4DE0D0090BED2 /* _RX.m in Sources */ = {isa = PBXBuildFile; fileRef = 26AAE4981F2B2A0B345D49C6FFF3F191 /* _RX.m */; };
+		E63D30C2209090D128D2266CC5779DA1 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B26A5D41DBB998BC91E988B0B68FFF /* Switch.swift */; };
+		E72B0C0D6CBD12E8A5F21B72CDDD7203 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442E13A5AA3E5B956BF394857AB8456C /* Never.swift */; };
+		E78BCA5E5168C44187E2B8A479663BE2 /* Observable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDB236E3E70B35781D525D0318E5BB7 /* Observable+Extensions.swift */; };
+		E8501FA1970C16E7C772C02D8159FC00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD57AA83FCA2E0F8E94E8CAFC455341C /* RxCollectionViewReactiveArrayDataSource.swift */; };
+		E9ED7FE4CE65BB533604E7AD81D236A5 /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B3B751B0C5F626CB6E8FCE543FF5CF5 /* NopDisposable.swift */; };
+		EA6916A705334537CA79073B9FF7BA5C /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2B40CC335CF4F90488701FB34D321D /* ConnectableObservableType.swift */; };
+		EB04FF1B2FE87A99D524B3A353ADC3EA /* RxGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D561015C9DD423C4695CE8F7CAE062 /* RxGesture.swift */; };
+		EB2A84A5948EBF2DF07E8C6C1535F69C /* _RXKVOObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF27BBCB2AAD5C679581C38EE2DC185 /* _RXKVOObserver.m */; };
+		EDD889910ED1B6E47D1D22912539C0C3 /* AnonymousObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFDC7869C929289A9CD3A92B63C692D1 /* AnonymousObservable.swift */; };
+		EE3F30ED84D01AA3F798CE0FF424F2B5 /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32333103781E0D7296DE45160EFFCF8A /* LockOwnerType.swift */; };
+		EFE9CC2266B78C141870E56568CE0A4B /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2DE95184E55408F0BFC4D170AF4C04 /* StartWith.swift */; };
+		F06E6FB5C72FA43030789513F4821926 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F709B0640631738B641635327262486 /* DelegateProxy.swift */; };
+		F0E76B087E7E5F0C0AC5AA247AB65401 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920C57CA223DED99EA2B9BF7416E8664 /* Amb.swift */; };
+		F0E9F066503AC19C46BC1AA084BAFD15 /* RxCLLocationManagerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1D85D88F45DA1940997764A3F22DA0 /* RxCLLocationManagerDelegateProxy.swift */; };
+		F0EE7E6B78C9D23E8B022BD87DE056C7 /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C8BBEADC28B99A09E31C0BC5FE57FD /* OperationQueueScheduler.swift */; };
+		F11BBCAE8E7A90157F5AE35594336B5D /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAFF37D2CE77D76494B7F42ABF4792A /* Rx.swift */; };
+		F150F627FA22644A5A75B5B046FF3B6B /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F618BDF7BC2AC6CC2A49F4069E5944 /* ConcurrentMainScheduler.swift */; };
+		F16FBB4B6EC68C9609A904B8BE63BA36 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686CEFDB56AF5DFB18118006274FA02 /* TakeLast.swift */; };
+		F1790D9553734F8D05439D4B89D6FE66 /* StableCompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A2FE6EDBAF67DE1651CFA7C30C0FA9 /* StableCompositeDisposable.swift */; };
+		F17C36EE5E47C26D58ACC1C16C169A83 /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06063B1BB0E18FA159CEC26B2275178D /* SingleAssignmentDisposable.swift */; };
+		F300A6D9B9E5AE90DC83258DC5E63E53 /* NSTextStorage+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB24918AFDA96F22951E15B52F35A8B /* NSTextStorage+Rx.swift */; };
+		F42EBA332695D4D99D6D6AE0531E8476 /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94C88848C57B60ABE5E9867B1942078 /* SingleAsync.swift */; };
+		F4BE7B053C0D4DC5F1CE34E2BD1D3C5A /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6D897F503A3460A4E195622BACB277 /* Debug.swift */; };
+		F5FD8B227B68EF7C52764E8C8C81A6D1 /* Observable+Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E897AFACD8C7C5E2A001D27DE0B4618 /* Observable+Binding.swift */; };
+		F61BF2C739E958D5E5D08C55E5EAF0F8 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371997EFA02B3641F6F5DCA3462F231D /* InvocableType.swift */; };
+		F683FDBA6C4E8E68A2779E54F74078E3 /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DF800B19E074DBC494C3F9A24063 /* BinaryDisposable.swift */; };
+		F6BB3FFD23B8534A7B485A347AFADAFC /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3FD3990B8A1E9548CB62F43886EADA /* ObserverType.swift */; };
+		F7D7F0E69267A2EC33065AC12526C089 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16B90AA9D152514C8ADF7451C1E90A4 /* Generate.swift */; };
+		F86837682196263E9D5F287348EB7B59 /* MessageSentObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF08F5702058168441B64713EBBB29D /* MessageSentObserver.swift */; };
+		F8CC9CB96DA7D4844F559C8C80088CD4 /* Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EEA1B9C1EA4C125354E33390B6E85E6 /* Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F9EA78A1A667DF3843D7E1F2D6630F38 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DCA1F1EC467C456DE2F6B57B5C35A6 /* Timer.swift */; };
+		FA705E2E270100E5C40A74D6DF388F71 /* _RX.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5384AAA357E269F58CCF248EF00C45 /* _RX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA9E64EF1F16C9A75321D321AB87C4A4 /* NSSlider+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EC70652ECAA2EB6A5CF971D91B21FF /* NSSlider+Rx.swift */; };
+		FBE1FA148B8A7875D8A705D0C9804762 /* NSObject+Rx+KVORepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72024E9C45ED7ABA10282FBC2A8B6CC9 /* NSObject+Rx+KVORepresentable.swift */; };
+		FC726DC55B0CC8247FECC7370424A3AE /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3C7C58743CE4D5B3CC5515C5803942 /* HistoricalSchedulerTimeConverter.swift */; };
+		FCCAD7210551E7E315057FE92B71710C /* UISlider+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7485BC75D5D55862531507EA811F6BA /* UISlider+Rx.swift */; };
+		FD3053D58B4B90A6385906722E65D5E5 /* DispatchQueueSchedulerQOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245AC5100739C5A8E44FBFE74CCCCC12 /* DispatchQueueSchedulerQOS.swift */; };
+		FD62880460C77E0A9BAF5FCF3EB7E4CA /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20587B5EBF4383E9A1A39FA525D0213B /* Empty.swift */; };
+		FE6A06583DCAD5929380A73780693C1D /* MessageSentObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF08F5702058168441B64713EBBB29D /* MessageSentObserver.swift */; };
+		FE7D4761ACE3A5A19A2C6CFC4C2D7DF2 /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A741BE56BF66F4F2242CF3B34F1E6D /* ScheduledItemType.swift */; };
+		FEDF1B082CA033A0952EA3E981B0A9B0 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7E2B288AEF9F04DA4D3DAF5B40E7F1 /* Repeat.swift */; };
+		FF235E5B69D1AEE2514F3CE78B761139 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3426C8436E0E44F1E70A1F7BC6D4BF63 /* Reduce.swift */; };
+		FF2C60939A60815A9D77688C30A55CE9 /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9289AF05996A8D7D12EAAF8869DBA2 /* SubscriptionDisposable.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		102827C3A99E45D1C6FDE5A5DBC0E68E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D7D2E8A3E11B6A93694AEE6F34218DD3;
+			remoteInfo = "Pods-RxGesture_OSX_Demo-RxSwift";
+		};
+		3B18CE2FF2F45E60306F01D5887056D3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D7D2E8A3E11B6A93694AEE6F34218DD3;
+			remoteInfo = "Pods-RxGesture_OSX_Demo-RxSwift";
+		};
+		9B45A1851F5175F17D0F160D545D2D22 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF39F572578F134BF8414A8D27FD3729;
+			remoteInfo = "Pods-RxGesture_iOS_Demo-RxGesture";
+		};
+		9B6B4A1F1ED7FC887699E49A2A6262A4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B0124864FA21CEC6CC3F9B3C55B6F65;
+			remoteInfo = "Pods-RxGesture_OSX_Demo-RxCocoa";
+		};
+		A189BB98A9127C953E6B4A32A68E859F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 614365A9E4840470AC452C75DD2858EC;
+			remoteInfo = "Pods-RxGesture_iOS_Demo-RxCocoa";
+		};
+		BAE5E5AF1B14DE4D1BBFC3E9FBBF1FC2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 614365A9E4840470AC452C75DD2858EC;
+			remoteInfo = "Pods-RxGesture_iOS_Demo-RxCocoa";
+		};
+		CA7750E5ABEF5F2B68D50415B80A5EC9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B27914C2D65E7BCA3CAB1D2365E645D;
+			remoteInfo = "Pods-RxGesture_iOS_Demo-RxSwift";
+		};
+		D191CE7C858A07E1680413AC79142656 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B0124864FA21CEC6CC3F9B3C55B6F65;
+			remoteInfo = "Pods-RxGesture_OSX_Demo-RxCocoa";
+		};
+		E19FE5C08FA3F61711C410D13B756BA0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B27914C2D65E7BCA3CAB1D2365E645D;
+			remoteInfo = "Pods-RxGesture_iOS_Demo-RxSwift";
+		};
+		EC09866E2A98A4329F1656536A729543 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FEC7E09BE7C35F9F8658D953E429D451;
+			remoteInfo = "Pods-RxGesture_OSX_Demo-RxGesture";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0047D7C07D4E7168D66A6B195B20AF58 /* ConcurrentDispatchQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConcurrentDispatchQueueScheduler.swift; path = RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift; sourceTree = "<group>"; };
+		018B5C8CFEFFB40F36662FA6FE88DAF1 /* NSButton+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSButton+Rx.swift"; path = "RxCocoa/OSX/NSButton+Rx.swift"; sourceTree = "<group>"; };
+		02736A0824ED21A5F170A055AAC18B5E /* Do.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Do.swift; path = RxSwift/Observables/Implementations/Do.swift; sourceTree = "<group>"; };
+		0278F3FA193A3C83B14B2E3F9ED87E2F /* ItemEvents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ItemEvents.swift; path = RxCocoa/iOS/Events/ItemEvents.swift; sourceTree = "<group>"; };
+		02A10A251161E99CA06BFBA191386FB4 /* RetryWhen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RetryWhen.swift; path = RxSwift/Observables/Implementations/RetryWhen.swift; sourceTree = "<group>"; };
+		032DD707905DA8D3C57277EF878F3240 /* Take.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Take.swift; path = RxSwift/Observables/Implementations/Take.swift; sourceTree = "<group>"; };
+		036645378416B45CDB8CE10B07BE2213 /* SerialDispatchQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SerialDispatchQueueScheduler.swift; path = RxSwift/Schedulers/SerialDispatchQueueScheduler.swift; sourceTree = "<group>"; };
+		0522CD8F0D5EA4DD356A6C34B68879AB /* WithLatestFrom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WithLatestFrom.swift; path = RxSwift/Observables/Implementations/WithLatestFrom.swift; sourceTree = "<group>"; };
+		06063B1BB0E18FA159CEC26B2275178D /* SingleAssignmentDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAssignmentDisposable.swift; path = RxSwift/Disposables/SingleAssignmentDisposable.swift; sourceTree = "<group>"; };
+		068C90A9229762E4F318F6CD34B2ECF5 /* Pods-RxGesture_iOS_Demo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-RxGesture_iOS_Demo-frameworks.sh"; sourceTree = "<group>"; };
+		06E0F99179E5CCB68C4721ECC9703E40 /* RxTextViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTextViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift; sourceTree = "<group>"; };
+		06E8FE7D88F5AF65F3E6D57C39B12F30 /* AnonymousInvocable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousInvocable.swift; path = RxSwift/Schedulers/Internal/AnonymousInvocable.swift; sourceTree = "<group>"; };
+		0905B95004BC92DB93247A62B00B3165 /* Map.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Map.swift; path = RxSwift/Observables/Implementations/Map.swift; sourceTree = "<group>"; };
+		0AC1F877E92090E34F5CE2FB79F4629D /* CLLocationManager+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CLLocationManager+Rx.swift"; path = "RxCocoa/Common/CLLocationManager+Rx.swift"; sourceTree = "<group>"; };
+		0BDB8D850932A64821E98B8CF500069E /* Pods-RxGesture_OSX_Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_OSX_Demo.release.xcconfig"; sourceTree = "<group>"; };
+		0C9289AF05996A8D7D12EAAF8869DBA2 /* SubscriptionDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriptionDisposable.swift; path = RxSwift/Disposables/SubscriptionDisposable.swift; sourceTree = "<group>"; };
+		0FED2EC4C912C80F8F0A4FE9E545CB4E /* SubjectType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubjectType.swift; path = RxSwift/Subjects/SubjectType.swift; sourceTree = "<group>"; };
+		10EAC6560D0E865FC286D0B2CEB21F8D /* ConnectableObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectableObservable.swift; path = RxSwift/Observables/Implementations/ConnectableObservable.swift; sourceTree = "<group>"; };
+		12B7233B7F267BF399EEED6714BCE42D /* Pods-RxGesture_iOS_Demo-RxGesture-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-RxGesture_iOS_Demo-RxGesture-dummy.m"; path = "../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-dummy.m"; sourceTree = "<group>"; };
+		1371EDFFD119B102C16B66F5769F97F0 /* Observable+Single.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Single.swift"; path = "RxSwift/Observables/Observable+Single.swift"; sourceTree = "<group>"; };
+		1541EFF54CE15FA4247A89DFB63268D8 /* String+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Rx.swift"; path = "RxSwift/Extensions/String+Rx.swift"; sourceTree = "<group>"; };
+		16B4F8DCF4CBA99637141D6CCD6AD93D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1769EE025DD222C127D3D32B83C90BC0 /* NSImageView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSImageView+Rx.swift"; path = "RxCocoa/OSX/NSImageView+Rx.swift"; sourceTree = "<group>"; };
+		17F984370AC1D8AD4B483F2E27E48830 /* Pods-RxGesture_OSX_Demo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-RxGesture_OSX_Demo-frameworks.sh"; sourceTree = "<group>"; };
+		19A8502B4392E2C35D5ECF8145E781DC /* Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Merge.swift; path = RxSwift/Observables/Implementations/Merge.swift; sourceTree = "<group>"; };
+		19E010F7B88BB02E629463A73BA403E1 /* Disposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Disposable.swift; path = RxSwift/Disposable.swift; sourceTree = "<group>"; };
+		1A0E104B9153F15585DEC6956D497ACD /* SynchronizedSubscribeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedSubscribeType.swift; path = RxSwift/Concurrency/SynchronizedSubscribeType.swift; sourceTree = "<group>"; };
+		1A2DA45028046C38FA03EA5A688E9AB4 /* RxSearchBarDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxSearchBarDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift; sourceTree = "<group>"; };
+		1B3B751B0C5F626CB6E8FCE543FF5CF5 /* NopDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NopDisposable.swift; path = RxSwift/Disposables/NopDisposable.swift; sourceTree = "<group>"; };
+		1E30F06ECF68CB0C48EA50C7EE7B2433 /* RxCollectionViewDataSourceProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxCollectionViewDataSourceProxy.swift; path = RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift; sourceTree = "<group>"; };
+		1F19AA9E3785650C8EB42205C1EC4C29 /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F4249BCB52EA315CF45C8AF750220C3 /* _RXDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _RXDelegateProxy.h; path = RxCocoa/Common/_RXDelegateProxy.h; sourceTree = "<group>"; };
+		20587B5EBF4383E9A1A39FA525D0213B /* Empty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Empty.swift; path = RxSwift/Observables/Implementations/Empty.swift; sourceTree = "<group>"; };
+		223D2D9A89527A00F2C9592CF7FE7DFB /* SkipWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SkipWhile.swift; path = RxSwift/Observables/Implementations/SkipWhile.swift; sourceTree = "<group>"; };
+		226B5AC3BB6D95D9409C54D83CFBBDD4 /* BooleanDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BooleanDisposable.swift; path = RxSwift/Disposables/BooleanDisposable.swift; sourceTree = "<group>"; };
+		236983DA69E6A12F58775605239117DE /* RefCountDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RefCountDisposable.swift; path = RxSwift/Disposables/RefCountDisposable.swift; sourceTree = "<group>"; };
+		245AC5100739C5A8E44FBFE74CCCCC12 /* DispatchQueueSchedulerQOS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DispatchQueueSchedulerQOS.swift; path = RxSwift/Schedulers/DispatchQueueSchedulerQOS.swift; sourceTree = "<group>"; };
+		2488AC35E99BBB5538B1BD95F7655E94 /* Observable+Bind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Bind.swift"; path = "RxCocoa/Common/Observable+Bind.swift"; sourceTree = "<group>"; };
+		2576CF8363182027D6275CCCF79BFF09 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIProgressView+Rx.swift"; path = "RxCocoa/iOS/UIProgressView+Rx.swift"; sourceTree = "<group>"; };
+		26AAE4981F2B2A0B345D49C6FFF3F191 /* _RX.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _RX.m; path = RxCocoa/Common/_RX.m; sourceTree = "<group>"; };
+		26F86A42574378E3C19BB20A1D4F6EE1 /* Observable+Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Debug.swift"; path = "RxSwift/Observables/Observable+Debug.swift"; sourceTree = "<group>"; };
+		283198B3A1BC9C9C64AF8776DF9D8602 /* Driver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Driver.swift; path = RxCocoa/Common/CocoaUnits/Driver/Driver.swift; sourceTree = "<group>"; };
+		2C6AB6AEB9265AFCBF6B63FE10D75B45 /* ReplaySubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReplaySubject.swift; path = RxSwift/Subjects/ReplaySubject.swift; sourceTree = "<group>"; };
+		2CDEF5835D5C10A026F090259385CC21 /* UITextField+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UITextField+Rx.swift"; path = "RxCocoa/iOS/UITextField+Rx.swift"; sourceTree = "<group>"; };
+		2D0298A8428E79167215D2B8D70D16A5 /* ObservableConvertibleType+Driver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ObservableConvertibleType+Driver.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/ObservableConvertibleType+Driver.swift"; sourceTree = "<group>"; };
+		2DE492C558DEBA31064661917BC71BE2 /* CurrentThreadScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CurrentThreadScheduler.swift; path = RxSwift/Schedulers/CurrentThreadScheduler.swift; sourceTree = "<group>"; };
+		2DF76949F9A826C7D066D20516A6268E /* UIView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Rx.swift"; path = "RxCocoa/iOS/UIView+Rx.swift"; sourceTree = "<group>"; };
+		2E09F8FD785663489A532E8A69164E9C /* SynchronizedUnsubscribeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedUnsubscribeType.swift; path = RxSwift/Concurrency/SynchronizedUnsubscribeType.swift; sourceTree = "<group>"; };
+		2E17907AF176E8F017DBA35163551D37 /* UIImagePickerController+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIImagePickerController+Rx.swift"; path = "RxCocoa/iOS/UIImagePickerController+Rx.swift"; sourceTree = "<group>"; };
+		2EA5E789256C909EFAB76C6238E9F905 /* NSGestureRecognizer+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSGestureRecognizer+Rx.swift"; sourceTree = "<group>"; };
+		2F12CA77D6F2C4B36E0E751A89004250 /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F709B0640631738B641635327262486 /* DelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DelegateProxy.swift; path = RxCocoa/Common/DelegateProxy.swift; sourceTree = "<group>"; };
+		32333103781E0D7296DE45160EFFCF8A /* LockOwnerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LockOwnerType.swift; path = RxSwift/Concurrency/LockOwnerType.swift; sourceTree = "<group>"; };
+		32DB01547F7219DFA5AFF3C2A27DC685 /* UIActivityIndicatorView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIActivityIndicatorView+Rx.swift"; path = "RxCocoa/iOS/UIActivityIndicatorView+Rx.swift"; sourceTree = "<group>"; };
+		33A5CCFF7C755C16BD3B5DB4FFE1F88D /* MainScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainScheduler.swift; path = RxSwift/Schedulers/MainScheduler.swift; sourceTree = "<group>"; };
+		3426C8436E0E44F1E70A1F7BC6D4BF63 /* Reduce.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Reduce.swift; path = RxSwift/Observables/Implementations/Reduce.swift; sourceTree = "<group>"; };
+		371997EFA02B3641F6F5DCA3462F231D /* InvocableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InvocableType.swift; path = RxSwift/Schedulers/Internal/InvocableType.swift; sourceTree = "<group>"; };
+		37B0B8B080F1E6B923BEFBBF2DC5B11C /* AddRef.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AddRef.swift; path = RxSwift/Observables/Implementations/AddRef.swift; sourceTree = "<group>"; };
+		3804ADE6554A61F56E0FCD797E6D3084 /* SectionedViewDataSourceType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SectionedViewDataSourceType.swift; path = RxCocoa/Common/SectionedViewDataSourceType.swift; sourceTree = "<group>"; };
+		383E8395E05602750FB92C87A2FDEB92 /* PanConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PanConfig.swift; sourceTree = "<group>"; };
+		3871A7C8372F1322E306860D1430882B /* Cancelable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cancelable.swift; path = RxSwift/Cancelable.swift; sourceTree = "<group>"; };
+		3923CF81B57F0AB60F4DE73C980321DD /* Event.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Event.swift; path = RxSwift/Event.swift; sourceTree = "<group>"; };
+		3A847199C59581AE111ED00A7096043A /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Queue.swift; path = RxSwift/DataStructures/Queue.swift; sourceTree = "<group>"; };
+		3A8C262F7B62C28B263F49AACFDFAB2D /* KVORepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KVORepresentable.swift; path = RxCocoa/Common/KVORepresentable.swift; sourceTree = "<group>"; };
+		3ADD86DB658ADA7B22F4A9E9D1DA25A8 /* SynchronizedOnType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedOnType.swift; path = RxSwift/Concurrency/SynchronizedOnType.swift; sourceTree = "<group>"; };
+		3C6C162A5F021385835632E3EDB7CC09 /* Pods-RxGesture_iOS_Demo.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-RxGesture_iOS_Demo.modulemap"; sourceTree = "<group>"; };
+		3C99CE41C2C08F13D0EFB93F9F1AA297 /* UIScrollView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIScrollView+Rx.swift"; path = "RxCocoa/iOS/UIScrollView+Rx.swift"; sourceTree = "<group>"; };
+		3CB24918AFDA96F22951E15B52F35A8B /* NSTextStorage+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSTextStorage+Rx.swift"; path = "RxCocoa/iOS/NSTextStorage+Rx.swift"; sourceTree = "<group>"; };
+		3D1D85D88F45DA1940997764A3F22DA0 /* RxCLLocationManagerDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxCLLocationManagerDelegateProxy.swift; path = RxCocoa/Common/Proxies/RxCLLocationManagerDelegateProxy.swift; sourceTree = "<group>"; };
+		3D5F0C9794F6E7E5EDE3E81BB3D21943 /* UIImageView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIImageView+Rx.swift"; path = "RxCocoa/iOS/UIImageView+Rx.swift"; sourceTree = "<group>"; };
+		3E11B5F9407F2460BF507A031F543A31 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3E46C8CA6BBF11ADED61F1E96D33D598 /* NSTextField+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSTextField+Rx.swift"; path = "RxCocoa/OSX/NSTextField+Rx.swift"; sourceTree = "<group>"; };
+		3E98F8FEECEC2DD9F966C9D3E8807071 /* Range.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Range.swift; path = RxSwift/Observables/Implementations/Range.swift; sourceTree = "<group>"; };
+		40731FA149D0C969EF2ACC2B814AAA39 /* Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m"; path = "../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m"; sourceTree = "<group>"; };
+		41262CC4216C45247331AC963D084351 /* Pods-RxGesture_OSX_Demo-RxCocoa.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-RxGesture_OSX_Demo-RxCocoa.modulemap"; sourceTree = "<group>"; };
+		41691D1578A4288F5D547260BF7422E4 /* DistinctUntilChanged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DistinctUntilChanged.swift; path = RxSwift/Observables/Implementations/DistinctUntilChanged.swift; sourceTree = "<group>"; };
+		419FD89DFCF42A6ADFE86D2D84B0EA46 /* ScheduledItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledItem.swift; path = RxSwift/Schedulers/Internal/ScheduledItem.swift; sourceTree = "<group>"; };
+		42922C460C6B4921C335F9A0AB78966B /* AsyncLock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncLock.swift; path = RxSwift/Concurrency/AsyncLock.swift; sourceTree = "<group>"; };
+		442E13A5AA3E5B956BF394857AB8456C /* Never.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Never.swift; path = RxSwift/Observables/Implementations/Never.swift; sourceTree = "<group>"; };
+		449F0019DD1F3E76574EB8C06356C328 /* DelaySubscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DelaySubscription.swift; path = RxSwift/Observables/Implementations/DelaySubscription.swift; sourceTree = "<group>"; };
+		45EC70652ECAA2EB6A5CF971D91B21FF /* NSSlider+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSSlider+Rx.swift"; path = "RxCocoa/OSX/NSSlider+Rx.swift"; sourceTree = "<group>"; };
+		46DD1AB167A06B315005919A9BD6E8B4 /* ControlEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ControlEvent.swift; path = RxCocoa/Common/CocoaUnits/ControlEvent.swift; sourceTree = "<group>"; };
+		477AECB674F89335ACC974874BAC99FC /* Logging.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Logging.swift; path = RxCocoa/Common/Logging.swift; sourceTree = "<group>"; };
+		49FBEB4800AA72C5B24F339E2CE4492A /* _RXDelegateProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _RXDelegateProxy.m; path = RxCocoa/Common/_RXDelegateProxy.m; sourceTree = "<group>"; };
+		4A2B40CC335CF4F90488701FB34D321D /* ConnectableObservableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectableObservableType.swift; path = RxSwift/ConnectableObservableType.swift; sourceTree = "<group>"; };
+		4B20F6146FF7DCA5A308859C677FAA81 /* UIControl+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIControl+Rx.swift"; path = "RxCocoa/iOS/UIControl+Rx.swift"; sourceTree = "<group>"; };
+		4B57D8DB71BDAB80D01EB772BB8B51EC /* ObserveOn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserveOn.swift; path = RxSwift/Observables/Implementations/ObserveOn.swift; sourceTree = "<group>"; };
+		4B860A00382AC06FCFA0D8436A433574 /* Pods-RxGesture_OSX_Demo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-RxGesture_OSX_Demo-acknowledgements.plist"; sourceTree = "<group>"; };
+		4BA5080CDADDA1683B24B8F83BC42549 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4BE2E8575BDC4E03E951EAE8E023EA7B /* Pods-RxGesture_OSX_Demo-RxGesture.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-RxGesture_OSX_Demo-RxGesture.modulemap"; sourceTree = "<group>"; };
+		4CDA9865788B870D2E0C9631A55AD2FC /* ControlProperty+Driver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ControlProperty+Driver.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/ControlProperty+Driver.swift"; sourceTree = "<group>"; };
+		521A807C1287A4736A5185E17EDD0D0F /* Pods-RxGesture_iOS_Demo-RxSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-RxGesture_iOS_Demo-RxSwift.modulemap"; path = "../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.modulemap"; sourceTree = "<group>"; };
+		52DE9731E7AB29C0A4F4994F544D31EC /* DisposeBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBase.swift; path = RxSwift/Disposables/DisposeBase.swift; sourceTree = "<group>"; };
+		53E085BA27253B4EFEDD426526E4A96A /* Bag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bag.swift; path = RxSwift/DataStructures/Bag.swift; sourceTree = "<group>"; };
+		54133C9D54D6BD5ED81DAE23B47861CA /* KVORepresentable+CoreGraphics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "KVORepresentable+CoreGraphics.swift"; path = "RxCocoa/Common/KVORepresentable+CoreGraphics.swift"; sourceTree = "<group>"; };
+		573193BEB3DE9B1053800EFB15956A04 /* SchedulerServices+Emulation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SchedulerServices+Emulation.swift"; path = "RxSwift/Schedulers/SchedulerServices+Emulation.swift"; sourceTree = "<group>"; };
+		58ECEFE2F4CC184ABFE4A7BD4F63F568 /* Pods-RxGesture_OSX_Demo-RxSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-RxGesture_OSX_Demo-RxSwift-dummy.m"; sourceTree = "<group>"; };
+		59638383E4045E9D58DD49A2FAD59AB2 /* UIStepper+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIStepper+Rx.swift"; path = "RxCocoa/iOS/UIStepper+Rx.swift"; sourceTree = "<group>"; };
+		5B14A01C0088D795DF56061F4DA5C947 /* Variable+Driver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Variable+Driver.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/Variable+Driver.swift"; sourceTree = "<group>"; };
+		5C5A1CF70E522B6D4494C37B1C06F6D3 /* UICollectionView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UICollectionView+Rx.swift"; path = "RxCocoa/iOS/UICollectionView+Rx.swift"; sourceTree = "<group>"; };
+		5DC848B1D95281036D21CC324D052753 /* RxTableViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTableViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift; sourceTree = "<group>"; };
+		5F569847A7107D9276E4725C50D0916D /* PriorityQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorityQueue.swift; path = RxSwift/DataStructures/PriorityQueue.swift; sourceTree = "<group>"; };
+		5F73DCC6D3F37BDB0EE4D0E020E4901D /* Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig"; path = "../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig"; sourceTree = "<group>"; };
+		5FA173D102727E0176EED982ADA11269 /* UIDatePicker+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIDatePicker+Rx.swift"; path = "RxCocoa/iOS/UIDatePicker+Rx.swift"; sourceTree = "<group>"; };
+		5FA6793E8440943D0A3CE5EC20DCC7FC /* Window.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Window.swift; path = RxSwift/Observables/Implementations/Window.swift; sourceTree = "<group>"; };
+		5FC278E77933E0D1F364DBD2B0A24180 /* ElementAt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementAt.swift; path = RxSwift/Observables/Implementations/ElementAt.swift; sourceTree = "<group>"; };
+		60F618BDF7BC2AC6CC2A49F4069E5944 /* ConcurrentMainScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConcurrentMainScheduler.swift; path = RxSwift/Schedulers/ConcurrentMainScheduler.swift; sourceTree = "<group>"; };
+		6125CFE9D1577552DB75431F0817A868 /* Pods-RxGesture_OSX_Demo-RxGesture-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-RxGesture_OSX_Demo-RxGesture-dummy.m"; sourceTree = "<group>"; };
+		613CFDD9885D7CC54BC0041A8B2E9FE8 /* Pods-RxGesture_iOS_Demo-RxGesture.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxGesture_iOS_Demo-RxGesture.xcconfig"; path = "../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.xcconfig"; sourceTree = "<group>"; };
+		634F4ECE00431123C06FD52C27501C64 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-RxGesture_iOS_Demo-RxGesture/Info.plist"; sourceTree = "<group>"; };
+		637B39D283F2B3C1CE39F900E3526F2C /* Pods-RxGesture_OSX_Demo-RxSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_OSX_Demo-RxSwift.xcconfig"; sourceTree = "<group>"; };
+		638D81BBC0A578B83C471D806B095768 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6399E931BEE7F5E5F5E04BAA0FC0DE34 /* NSLayoutConstraint+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSLayoutConstraint+Rx.swift"; path = "RxCocoa/Common/NSLayoutConstraint+Rx.swift"; sourceTree = "<group>"; };
+		6487EE29EEB4C56EED2333CF8AA5A55D /* Pods-RxGesture_OSX_Demo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-RxGesture_OSX_Demo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		65C5DCE08601B273DE0CF84D2AC1CA7D /* RxTableViewDataSourceProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTableViewDataSourceProxy.swift; path = RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift; sourceTree = "<group>"; };
+		65D1EB659125EA3969D59014B9F4E1A4 /* Producer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Producer.swift; path = RxSwift/Observables/Implementations/Producer.swift; sourceTree = "<group>"; };
+		666CEAE2C63819EF5FAC680D6243A456 /* Sequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Sequence.swift; path = RxSwift/Observables/Implementations/Sequence.swift; sourceTree = "<group>"; };
+		66A938D2640AAB94C102006232D3177B /* Timeout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Timeout.swift; path = RxSwift/Observables/Implementations/Timeout.swift; sourceTree = "<group>"; };
+		674637809C1638D6E46627D0A7363E43 /* RxScrollViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxScrollViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift; sourceTree = "<group>"; };
+		680753ED29B2B36844E7BF1D3EC725DE /* VirtualTimeConverterType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VirtualTimeConverterType.swift; path = RxSwift/Schedulers/VirtualTimeConverterType.swift; sourceTree = "<group>"; };
+		6A0028F11D3A65960062328C /* TapConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TapConfig.swift; sourceTree = "<group>"; };
+		6A7E2B288AEF9F04DA4D3DAF5B40E7F1 /* Repeat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Repeat.swift; path = RxSwift/Observables/Implementations/Repeat.swift; sourceTree = "<group>"; };
+		6B52DF800B19E074DBC494C3F9A24063 /* BinaryDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BinaryDisposable.swift; path = RxSwift/Disposables/BinaryDisposable.swift; sourceTree = "<group>"; };
+		6CD4E7DF61DAAA84A22AB05AD877367C /* UITextView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UITextView+Rx.swift"; path = "RxCocoa/iOS/UITextView+Rx.swift"; sourceTree = "<group>"; };
+		6E0C7DD780E181D0F5EB28D77EDB199C /* SerialDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SerialDisposable.swift; path = RxSwift/Disposables/SerialDisposable.swift; sourceTree = "<group>"; };
+		6E477EE3500BD6A016CE1951B989CF75 /* RxCocoa.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxCocoa.swift; path = RxCocoa/Common/RxCocoa.swift; sourceTree = "<group>"; };
+		6F0F0AF42A8ACC55406B4D1B3531B75C /* Pods-RxGesture_iOS_Demo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-RxGesture_iOS_Demo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		6FD15299911C10004D6C338D4883BEA6 /* ImmediateSchedulerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImmediateSchedulerType.swift; path = RxSwift/ImmediateSchedulerType.swift; sourceTree = "<group>"; };
+		70AF53C1EA75011D56334E4AB4C72E91 /* ControlProperty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ControlProperty.swift; path = RxCocoa/Common/CocoaUnits/ControlProperty.swift; sourceTree = "<group>"; };
+		70C8BBEADC28B99A09E31C0BC5FE57FD /* OperationQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OperationQueueScheduler.swift; path = RxSwift/Schedulers/OperationQueueScheduler.swift; sourceTree = "<group>"; };
+		713CD0C782C89D147C113A835FA5BD81 /* Zip+arity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Zip+arity.swift"; path = "RxSwift/Observables/Implementations/Zip+arity.swift"; sourceTree = "<group>"; };
+		714C5305FFAFC2F0793D969801E49179 /* NAryDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NAryDisposable.swift; path = RxSwift/Disposables/NAryDisposable.swift; sourceTree = "<group>"; };
+		71AFAD963301C46BC7BC87E5B3D2F396 /* Driver+Operators+arity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Driver+Operators+arity.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/Driver+Operators+arity.swift"; sourceTree = "<group>"; };
+		72024E9C45ED7ABA10282FBC2A8B6CC9 /* NSObject+Rx+KVORepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Rx+KVORepresentable.swift"; path = "RxCocoa/Common/Observables/NSObject+Rx+KVORepresentable.swift"; sourceTree = "<group>"; };
+		72A3310CDED6F0B1AC6B42A981CC578B /* ControlTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ControlTarget.swift; path = RxCocoa/Common/Observables/Implementations/ControlTarget.swift; sourceTree = "<group>"; };
+		731149DD4332983A51195DAE8684A126 /* NSView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSView+Rx.swift"; path = "RxCocoa/OSX/NSView+Rx.swift"; sourceTree = "<group>"; };
+		73E7917F369F21F0188070F597CDE8E6 /* KVORepresentable+Swift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "KVORepresentable+Swift.swift"; path = "RxCocoa/Common/KVORepresentable+Swift.swift"; sourceTree = "<group>"; };
+		754393E014D5DDCFD533E33A02544594 /* NSView+RxGesture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSView+RxGesture.swift"; sourceTree = "<group>"; };
+		777BF9DD554FFC95F2DFA576184620D8 /* NSNotificationCenter+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSNotificationCenter+Rx.swift"; path = "RxCocoa/Common/Observables/NSNotificationCenter+Rx.swift"; sourceTree = "<group>"; };
+		784144428CC006C85BDB001BA7FC389B /* Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch"; path = "../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch"; sourceTree = "<group>"; };
+		784DCD30FFABD70154CB39E13ADC428B /* ShareReplay1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareReplay1.swift; path = RxSwift/Observables/Implementations/ShareReplay1.swift; sourceTree = "<group>"; };
+		7968685A24D6C361EE9E76D7D17C454B /* Observable+Creation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Creation.swift"; path = "RxSwift/Observables/Observable+Creation.swift"; sourceTree = "<group>"; };
+		79EEA13950D3C7E26EA2C570F80B66C2 /* CompositeDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompositeDisposable.swift; path = RxSwift/Disposables/CompositeDisposable.swift; sourceTree = "<group>"; };
+		7BCED313175C4FDCE4ABF2985910FD43 /* Sink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Sink.swift; path = RxSwift/Observables/Implementations/Sink.swift; sourceTree = "<group>"; };
+		7C0C813650AFCAACE69C0BBAF5A9D251 /* Lock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Lock.swift; path = RxSwift/Concurrency/Lock.swift; sourceTree = "<group>"; };
+		7CD8DFA3BDA378BDC5FF885379349130 /* _RXObjCRuntime.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _RXObjCRuntime.m; path = RxCocoa/Common/_RXObjCRuntime.m; sourceTree = "<group>"; };
+		7CDC591FE27EDF0166C359C990E9F4FA /* Pods-RxGesture_OSX_Demo.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-RxGesture_OSX_Demo.modulemap"; sourceTree = "<group>"; };
+		7D5E833F61266E85C52B9AFA5BDA55F0 /* KVOObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KVOObserver.swift; path = RxCocoa/Common/Observables/Implementations/KVOObserver.swift; sourceTree = "<group>"; };
+		7E897AFACD8C7C5E2A001D27DE0B4618 /* Observable+Binding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Binding.swift"; path = "RxSwift/Observables/Observable+Binding.swift"; sourceTree = "<group>"; };
+		7F4253EEA0015AD9E0F2EDD399E50ED6 /* Pods-RxGesture_iOS_Demo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-RxGesture_iOS_Demo-resources.sh"; sourceTree = "<group>"; };
+		7F9DCD3DE6178587C27AF8D985383E08 /* UIView+RxGesture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+RxGesture.swift"; sourceTree = "<group>"; };
+		80464EA0B50C6A06A9C5061AA0E72B6E /* Deferred.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deferred.swift; path = RxSwift/Observables/Implementations/Deferred.swift; sourceTree = "<group>"; };
+		810CDFDD1F29B38A57A777A0E34E51F3 /* Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h"; sourceTree = "<group>"; };
+		8267675773E498B54102DEDDB7B15C3E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-RxGesture_iOS_Demo-RxCocoa/Info.plist"; sourceTree = "<group>"; };
+		82A721AFC5D1B757D919FEC84F9FEF74 /* Pods-RxGesture_OSX_Demo-RxGesture.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_OSX_Demo-RxGesture.xcconfig"; sourceTree = "<group>"; };
+		83425313765F7ED109DC81D7BADC7B5A /* UIButton+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIButton+Rx.swift"; path = "RxCocoa/iOS/UIButton+Rx.swift"; sourceTree = "<group>"; };
+		85B26A5D41DBB998BC91E988B0B68FFF /* Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Switch.swift; path = RxSwift/Observables/Implementations/Switch.swift; sourceTree = "<group>"; };
+		8614B5BCCE597A517451A65FDCCF091B /* Pods-RxGesture_OSX_Demo-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-umbrella.h"; sourceTree = "<group>"; };
+		867FB6D9CD5ADD06727AA1E89197078D /* ObservableConvertibleType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableConvertibleType.swift; path = RxSwift/ObservableConvertibleType.swift; sourceTree = "<group>"; };
+		8806CC77B1040592A24B4F57B756C9AA /* Observable+Time.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Time.swift"; path = "RxSwift/Observables/Observable+Time.swift"; sourceTree = "<group>"; };
+		880EC46B2EA4171F124091B6A8EEC9BE /* Throttle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Throttle.swift; path = RxSwift/Observables/Implementations/Throttle.swift; sourceTree = "<group>"; };
+		8822B80A6A868B58E68512A9C1288FC8 /* Pods-RxGesture_OSX_Demo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-RxGesture_OSX_Demo-dummy.m"; sourceTree = "<group>"; };
+		89361C46E5D991265A6D4AECA7F2EAC4 /* RxCocoa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RxCocoa.h; path = RxCocoa/RxCocoa.h; sourceTree = "<group>"; };
+		8A12623F1AB0752800B1DB10DF0417CF /* Driver+Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Driver+Subscription.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/Driver+Subscription.swift"; sourceTree = "<group>"; };
+		8A47B3D1B773D68299EDABB9A4D54E96 /* Variable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Variable.swift; path = RxSwift/Subjects/Variable.swift; sourceTree = "<group>"; };
+		8A4F910A4EF4840DF1A5FA245812BEB1 /* DeallocObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeallocObservable.swift; path = RxCocoa/Common/Observables/Implementations/DeallocObservable.swift; sourceTree = "<group>"; };
+		8ABCA9D25D5ED7D25B873051B0E2BAB5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8BC1538A9C562465360DC7DEE22C8AB0 /* RxGesture.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxGesture.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BF27BBCB2AAD5C679581C38EE2DC185 /* _RXKVOObserver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _RXKVOObserver.m; path = RxCocoa/Common/_RXKVOObserver.m; sourceTree = "<group>"; };
+		8D3FD3990B8A1E9548CB62F43886EADA /* ObserverType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserverType.swift; path = RxSwift/ObserverType.swift; sourceTree = "<group>"; };
+		8E3CECCCF5890CBE65780B3C8D44E2B1 /* UIGestureRecognizer+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIGestureRecognizer+Rx.swift"; path = "RxCocoa/iOS/UIGestureRecognizer+Rx.swift"; sourceTree = "<group>"; };
+		8F0081C0EB913B4A12C9BA7F9E2C44CA /* CombineLatest+arity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CombineLatest+arity.swift"; path = "RxSwift/Observables/Implementations/CombineLatest+arity.swift"; sourceTree = "<group>"; };
+		8F88D395752826616234A8383CBDCA3D /* RxCollectionViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxCollectionViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift; sourceTree = "<group>"; };
+		8FB5D2484879C5E0D0AC211D9FC603D5 /* CombineLatest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CombineLatest.swift; path = RxSwift/Observables/Implementations/CombineLatest.swift; sourceTree = "<group>"; };
+		90F97FBA1E50C1F43EAF8F3FAABD06AB /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		920C57CA223DED99EA2B9BF7416E8664 /* Amb.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Amb.swift; path = RxSwift/Observables/Implementations/Amb.swift; sourceTree = "<group>"; };
+		935D94469ED0B54EACC3A4C0F12B4646 /* RxCollectionViewDataSourceType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxCollectionViewDataSourceType.swift; path = RxCocoa/iOS/Protocols/RxCollectionViewDataSourceType.swift; sourceTree = "<group>"; };
+		937967AE1F14874EF338B1B8F57AA23B /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UITabBarItem+Rx.swift"; path = "RxCocoa/iOS/UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
+		93F4DB97B25A1296A903B4E94A63FB61 /* Pods-RxGesture_iOS_Demo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-RxGesture_iOS_Demo-acknowledgements.plist"; sourceTree = "<group>"; };
+		94E8B074971AF38C0412AE173DB4552D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		95792EE983BD8CEAA248950D147179F7 /* NSControl+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSControl+Rx.swift"; path = "RxCocoa/OSX/NSControl+Rx.swift"; sourceTree = "<group>"; };
+		969EF9A054D7A4FF9D52EC47F03E29BB /* Pods-RxGesture_OSX_Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_OSX_Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		97E089F34EA8E281F450990124ADE867 /* Pods-RxGesture_iOS_Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_iOS_Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		9A2B0DA384E6A125B6430754BD9E8241 /* UISegmentedControl+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UISegmentedControl+Rx.swift"; path = "RxCocoa/iOS/UISegmentedControl+Rx.swift"; sourceTree = "<group>"; };
+		9C6B788D60B66AC712BFEF712D9BE4B2 /* UIApplication+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIApplication+Rx.swift"; path = "RxCocoa/iOS/UIApplication+Rx.swift"; sourceTree = "<group>"; };
+		9CE5313DC68E5A2FFE47DB9B6FC673E6 /* KVOObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KVOObservable.swift; path = RxCocoa/Common/Observables/Implementations/KVOObservable.swift; sourceTree = "<group>"; };
+		9D04517DD6AD2781E4CB927E673828D5 /* Zip+CollectionType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Zip+CollectionType.swift"; path = "RxSwift/Observables/Implementations/Zip+CollectionType.swift"; sourceTree = "<group>"; };
+		9D76728BF899DC869752E1AEF92F2522 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		9DD6A6C23C63D4EB73064E6C68E20CD5 /* Observable+StandardSequenceOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+StandardSequenceOperators.swift"; path = "RxSwift/Observables/Observable+StandardSequenceOperators.swift"; sourceTree = "<group>"; };
+		9EBAC0789FA5CD3B9A97859B6633DD22 /* Buffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Buffer.swift; path = RxSwift/Observables/Implementations/Buffer.swift; sourceTree = "<group>"; };
+		9EEA1B9C1EA4C125354E33390B6E85E6 /* Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h"; path = "../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h"; sourceTree = "<group>"; };
+		A0F993C4C6D6C90DB6204A41E10A910E /* Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m"; sourceTree = "<group>"; };
+		A16B90AA9D152514C8ADF7451C1E90A4 /* Generate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generate.swift; path = RxSwift/Observables/Implementations/Generate.swift; sourceTree = "<group>"; };
+		A23025D7CBEA011BDDB9A5ECF666C1E8 /* SubscribeOn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscribeOn.swift; path = RxSwift/Observables/Implementations/SubscribeOn.swift; sourceTree = "<group>"; };
+		A36FEB7BB3E2CD50B80A49D235925AF3 /* Pods-RxGesture_iOS_Demo-RxCocoa.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-RxGesture_iOS_Demo-RxCocoa.modulemap"; path = "../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.modulemap"; sourceTree = "<group>"; };
+		A3B83162A671B863092C509640455BB1 /* ToArray.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToArray.swift; path = RxSwift/Observables/Implementations/ToArray.swift; sourceTree = "<group>"; };
+		A486D9E086D5087509C0FA917C16E181 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A7485BC75D5D55862531507EA811F6BA /* UISlider+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UISlider+Rx.swift"; path = "RxCocoa/iOS/UISlider+Rx.swift"; sourceTree = "<group>"; };
+		A7C8FF6E8BCA336FC4D4600B633328D2 /* Pods-RxGesture_iOS_Demo-RxGesture.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-RxGesture_iOS_Demo-RxGesture.modulemap"; path = "../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.modulemap"; sourceTree = "<group>"; };
+		A9446ADAA8A85A0CD4223AB8788DC5B6 /* Pods-RxGesture_OSX_Demo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-RxGesture_OSX_Demo-resources.sh"; sourceTree = "<group>"; };
+		A995AACF502C4037D6FBC4C6112ED3BB /* Sample.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Sample.swift; path = RxSwift/Observables/Implementations/Sample.swift; sourceTree = "<group>"; };
+		A9BF5397CE64E09EB5C37D737FA40398 /* RecursiveScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecursiveScheduler.swift; path = RxSwift/Schedulers/RecursiveScheduler.swift; sourceTree = "<group>"; };
+		AC31759D90FFBB778349105CD32B82A0 /* TailRecursiveSink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TailRecursiveSink.swift; path = RxSwift/Observers/TailRecursiveSink.swift; sourceTree = "<group>"; };
+		ACDB236E3E70B35781D525D0318E5BB7 /* Observable+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Extensions.swift"; path = "RxSwift/Observable+Extensions.swift"; sourceTree = "<group>"; };
+		AD57AA83FCA2E0F8E94E8CAFC455341C /* RxCollectionViewReactiveArrayDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxCollectionViewReactiveArrayDataSource.swift; path = RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift; sourceTree = "<group>"; };
+		AE2DE95184E55408F0BFC4D170AF4C04 /* StartWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StartWith.swift; path = RxSwift/Observables/Implementations/StartWith.swift; sourceTree = "<group>"; };
+		AEDB7B436E22D693CB5360DB88CE7450 /* UILabel+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UILabel+Rx.swift"; path = "RxCocoa/iOS/UILabel+Rx.swift"; sourceTree = "<group>"; };
+		AFE010FEC036F74911E6F9609402C03F /* Pods-RxGesture_OSX_Demo-RxCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_OSX_Demo-RxCocoa.xcconfig"; sourceTree = "<group>"; };
+		B0105A3A5AF33D1CF3973AD0CF4AEB9C /* InvocableScheduledItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InvocableScheduledItem.swift; path = RxSwift/Schedulers/Internal/InvocableScheduledItem.swift; sourceTree = "<group>"; };
+		B54EEB7F3D9B9D4D2E5708405A57F65E /* TakeUntil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeUntil.swift; path = RxSwift/Observables/Implementations/TakeUntil.swift; sourceTree = "<group>"; };
+		B594A1B0AF0D78EE827EB80F48CFEDDA /* SchedulerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SchedulerType.swift; path = RxSwift/SchedulerType.swift; sourceTree = "<group>"; };
+		B5B69664E4718AC7434121C115138625 /* Observable+Aggregate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Aggregate.swift"; path = "RxSwift/Observables/Observable+Aggregate.swift"; sourceTree = "<group>"; };
+		B746BEBFCD9CFA793E10E15D5E7B47D4 /* Just.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Just.swift; path = RxSwift/Observables/Implementations/Just.swift; sourceTree = "<group>"; };
+		B8393E60BACCB4386FBDC6A62A9FA561 /* Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h"; sourceTree = "<group>"; };
+		B8A2FE6EDBAF67DE1651CFA7C30C0FA9 /* StableCompositeDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StableCompositeDisposable.swift; path = RxSwift/Disposables/StableCompositeDisposable.swift; sourceTree = "<group>"; };
+		B938000B6A988DBB740EE2ED9F411571 /* RotateConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RotateConfig.swift; sourceTree = "<group>"; };
+		B94D6C7DD2DDCFDF47973632D61DB036 /* Observable+Multiple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Multiple.swift"; path = "RxSwift/Observables/Observable+Multiple.swift"; sourceTree = "<group>"; };
+		B9D561015C9DD423C4695CE8F7CAE062 /* RxGesture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RxGesture.swift; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BC5384AAA357E269F58CCF248EF00C45 /* _RX.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _RX.h; path = RxCocoa/Common/_RX.h; sourceTree = "<group>"; };
+		BFA9612F9925AA3168C6A101B4C99CEF /* UITableView+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UITableView+Rx.swift"; path = "RxCocoa/iOS/UITableView+Rx.swift"; sourceTree = "<group>"; };
+		BFFB4F5995EE9165EFF01A1B67E31329 /* AnonymousObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousObserver.swift; path = RxSwift/Observers/AnonymousObserver.swift; sourceTree = "<group>"; };
+		C25308CFE7CECE3CF7E9AC0EBBD33AF9 /* Catch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catch.swift; path = RxSwift/Observables/Implementations/Catch.swift; sourceTree = "<group>"; };
+		C3923EA7357FC6223BC856AAE0F07580 /* ImmediateScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImmediateScheduler.swift; path = RxSwift/Schedulers/ImmediateScheduler.swift; sourceTree = "<group>"; };
+		C3A0C86A2E540C585BD9EED8227FC082 /* SkipUntil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SkipUntil.swift; path = RxSwift/Observables/Implementations/SkipUntil.swift; sourceTree = "<group>"; };
+		C4122641759BCB149F3FCADD5C3268F7 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = RxSwift/Observables/Implementations/Error.swift; sourceTree = "<group>"; };
+		C63811859DE646A04ED30107BC30950A /* Multicast.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Multicast.swift; path = RxSwift/Observables/Implementations/Multicast.swift; sourceTree = "<group>"; };
+		C64491ABA744A4BD99C4CB1D733B5DA3 /* RxMutableBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxMutableBox.swift; path = RxSwift/RxMutableBox.swift; sourceTree = "<group>"; };
+		C686CEFDB56AF5DFB18118006274FA02 /* TakeLast.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeLast.swift; path = RxSwift/Observables/Implementations/TakeLast.swift; sourceTree = "<group>"; };
+		C7A741BE56BF66F4F2242CF3B34F1E6D /* ScheduledItemType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledItemType.swift; path = RxSwift/Schedulers/Internal/ScheduledItemType.swift; sourceTree = "<group>"; };
+		C7E745319BCA81A3F171ED2C1DF23643 /* Zip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Zip.swift; path = RxSwift/Observables/Implementations/Zip.swift; sourceTree = "<group>"; };
+		C862CF3BD7290855D8AD7565CD8E2666 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = RxSwift/Errors.swift; sourceTree = "<group>"; };
+		C87E53818AF138ACF5D61B3D7D6E5274 /* Skip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Skip.swift; path = RxSwift/Observables/Implementations/Skip.swift; sourceTree = "<group>"; };
+		C920A009DD877D098FB578E0E50EBFD6 /* Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch"; sourceTree = "<group>"; };
+		CA440FABEECC06934002C5B7DFFD96C3 /* BehaviorSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BehaviorSubject.swift; path = RxSwift/Subjects/BehaviorSubject.swift; sourceTree = "<group>"; };
+		CA682272C2916EFCE819012AA8F6F4C6 /* PublishSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PublishSubject.swift; path = RxSwift/Subjects/PublishSubject.swift; sourceTree = "<group>"; };
+		CAAFF37D2CE77D76494B7F42ABF4792A /* Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rx.swift; path = RxSwift/Rx.swift; sourceTree = "<group>"; };
+		CAC81FC6ADF84CBF9D24DF18F08820B7 /* AnonymousDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousDisposable.swift; path = RxSwift/Disposables/AnonymousDisposable.swift; sourceTree = "<group>"; };
+		CB32E46DA8057A3A622F29F4500772A2 /* Scan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scan.swift; path = RxSwift/Observables/Implementations/Scan.swift; sourceTree = "<group>"; };
+		CB48DAD7D5163991153C05BD30040B6D /* _RXObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _RXObjCRuntime.h; path = RxCocoa/Common/_RXObjCRuntime.h; sourceTree = "<group>"; };
+		CCFDBBFF08F74F9511DF21F873EABE86 /* NSObject+Rx+RawRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Rx+RawRepresentable.swift"; path = "RxCocoa/Common/Observables/NSObject+Rx+RawRepresentable.swift"; sourceTree = "<group>"; };
+		CF5F9B539C916CEB13C073BD9B8706C9 /* UIBindingObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIBindingObserver.swift; path = RxCocoa/Common/CocoaUnits/UIBindingObserver.swift; sourceTree = "<group>"; };
+		D06B278E015398E2A3B9AB600AD200F1 /* Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch"; path = "../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch"; sourceTree = "<group>"; };
+		D0E9E99E1790D8207298D944DDA5D4A2 /* VirtualTimeScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VirtualTimeScheduler.swift; path = RxSwift/Schedulers/VirtualTimeScheduler.swift; sourceTree = "<group>"; };
+		D12DB9FC05ECEBD079763E18E22438A0 /* DelegateProxyType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DelegateProxyType.swift; path = RxCocoa/Common/DelegateProxyType.swift; sourceTree = "<group>"; };
+		D1541DD57D56EB09CEF071E8D1144E48 /* Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h"; path = "../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h"; sourceTree = "<group>"; };
+		D2AD1791E2917EF6FCE255F4894FA8AD /* ObservableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableType.swift; path = RxSwift/ObservableType.swift; sourceTree = "<group>"; };
+		D368C07F4793B141BBE46A5B8453B177 /* ObserverBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserverBase.swift; path = RxSwift/Observers/ObserverBase.swift; sourceTree = "<group>"; };
+		D72318DBF092553E249C7DEA4BD4BEA0 /* Pods-RxGesture_iOS_Demo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-RxGesture_iOS_Demo-dummy.m"; sourceTree = "<group>"; };
+		D859CDF029BE59A16868AB0E614D41BB /* RxTableViewReactiveArrayDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTableViewReactiveArrayDataSource.swift; path = RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift; sourceTree = "<group>"; };
+		D91B8FB88CC735C3CC651A2DDAA219E5 /* Observable+Concurrency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Observable+Concurrency.swift"; path = "RxSwift/Observables/Observable+Concurrency.swift"; sourceTree = "<group>"; };
+		D94C88848C57B60ABE5E9867B1942078 /* SingleAsync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAsync.swift; path = RxSwift/Observables/Implementations/SingleAsync.swift; sourceTree = "<group>"; };
+		D9688474E44B841F6129B4FAFFB2C565 /* ObserveOnSerialDispatchQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserveOnSerialDispatchQueue.swift; path = RxSwift/Observables/Implementations/ObserveOnSerialDispatchQueue.swift; sourceTree = "<group>"; };
+		D9CDE42D609590B6AA8AAD038BF20E21 /* TakeWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeWhile.swift; path = RxSwift/Observables/Implementations/TakeWhile.swift; sourceTree = "<group>"; };
+		D9F0A2FEE585A9018680D5769208A755 /* Concat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Concat.swift; path = RxSwift/Observables/Implementations/Concat.swift; sourceTree = "<group>"; };
+		DA208E4396D571B3FF2C758E089F3C95 /* Observable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Observable.swift; path = RxSwift/Observable.swift; sourceTree = "<group>"; };
+		DA6D897F503A3460A4E195622BACB277 /* Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Debug.swift; path = RxSwift/Observables/Implementations/Debug.swift; sourceTree = "<group>"; };
+		DBD5C714DE2DE3862DE6DD9ABF4BA0E0 /* Pods_RxGesture_iOS_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RxGesture_iOS_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD0BF625CE8A09C228BDA4F907267DA2 /* UISearchBar+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UISearchBar+Rx.swift"; path = "RxCocoa/iOS/UISearchBar+Rx.swift"; sourceTree = "<group>"; };
+		DD670E6BA419147639CA62FC8C3CEDA5 /* Platform.Linux.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Linux.swift; path = RxSwift/Platform/Platform.Linux.swift; sourceTree = "<group>"; };
+		DD67C1AB5326A859DF36368BF25BED53 /* Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch"; sourceTree = "<group>"; };
+		DE379A21FCEBCEC0E0E426D9A123F760 /* Driver+Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Driver+Operators.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift"; sourceTree = "<group>"; };
+		DE4BF2809DFC533229426FC2B1D4AF91 /* RxTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTarget.swift; path = RxCocoa/Common/RxTarget.swift; sourceTree = "<group>"; };
+		DF3C7C58743CE4D5B3CC5515C5803942 /* HistoricalSchedulerTimeConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoricalSchedulerTimeConverter.swift; path = RxSwift/Schedulers/HistoricalSchedulerTimeConverter.swift; sourceTree = "<group>"; };
+		DFDC7869C929289A9CD3A92B63C692D1 /* AnonymousObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousObservable.swift; path = RxSwift/Observables/Implementations/AnonymousObservable.swift; sourceTree = "<group>"; };
+		E058D4EBE0ECDD108B8578F0C62D285A /* ControlEvent+Driver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ControlEvent+Driver.swift"; path = "RxCocoa/Common/CocoaUnits/Driver/ControlEvent+Driver.swift"; sourceTree = "<group>"; };
+		E0BD34020D1CF5E582610A08BF646C57 /* Pods_RxGesture_OSX_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RxGesture_OSX_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E145F810DEFF07BCE812538BFA651708 /* ShareReplay1WhileConnected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareReplay1WhileConnected.swift; path = RxSwift/Observables/Implementations/ShareReplay1WhileConnected.swift; sourceTree = "<group>"; };
+		E1C544817D76E71D828DB3AE0EE5DFA3 /* InfiniteSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteSequence.swift; path = RxSwift/DataStructures/InfiniteSequence.swift; sourceTree = "<group>"; };
+		E32F9EEBC2569CC8B22C59582C0E2D35 /* Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch"; sourceTree = "<group>"; };
+		E34A5CB470BDF4610D116B4C6E6310CC /* Using.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Using.swift; path = RxSwift/Observables/Implementations/Using.swift; sourceTree = "<group>"; };
+		E4DCA1F1EC467C456DE2F6B57B5C35A6 /* Timer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Timer.swift; path = RxSwift/Observables/Implementations/Timer.swift; sourceTree = "<group>"; };
+		E592BE42F6C322EF48759A3D652B83BA /* Pods-RxGesture_iOS_Demo-RxSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-RxGesture_iOS_Demo-RxSwift-dummy.m"; path = "../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-dummy.m"; sourceTree = "<group>"; };
+		E7731A4628E596D95ACD0AFE6EEBBA43 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = RxSwift/Observables/Implementations/Filter.swift; sourceTree = "<group>"; };
+		EB39ED08E4C74181954C6B42D69F7FB7 /* _RXKVOObserver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _RXKVOObserver.h; path = RxCocoa/Common/_RXKVOObserver.h; sourceTree = "<group>"; };
+		EDBB3142C058BFF8F0B79E20C43D86F8 /* SynchronizedDisposeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedDisposeType.swift; path = RxSwift/Concurrency/SynchronizedDisposeType.swift; sourceTree = "<group>"; };
+		F0C4B9D95966A3DD638408DD2AC9A1C1 /* UISwitch+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UISwitch+Rx.swift"; path = "RxCocoa/iOS/UISwitch+Rx.swift"; sourceTree = "<group>"; };
+		F20316FCE33298DCDDE596E17F8ABF9B /* UIBarButtonItem+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIBarButtonItem+Rx.swift"; path = "RxCocoa/iOS/UIBarButtonItem+Rx.swift"; sourceTree = "<group>"; };
+		F2C2A9E19936B336BC0C7AE82D875826 /* RxTableViewDataSourceType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTableViewDataSourceType.swift; path = RxCocoa/iOS/Protocols/RxTableViewDataSourceType.swift; sourceTree = "<group>"; };
+		F46C790F82DD42B1C1A090BF739A5BC5 /* Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch"; path = "../Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch"; sourceTree = "<group>"; };
+		F5079F022D850EE97985FE670AE654D3 /* NSURLSession+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSession+Rx.swift"; path = "RxCocoa/Common/Observables/NSURLSession+Rx.swift"; sourceTree = "<group>"; };
+		F52B7AE23C229717D736C40F90B8D574 /* AnyObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyObserver.swift; path = RxSwift/AnyObserver.swift; sourceTree = "<group>"; };
+		F60D78F33A072FBB5C97E5841B867C77 /* HistoricalScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoricalScheduler.swift; path = RxSwift/Schedulers/HistoricalScheduler.swift; sourceTree = "<group>"; };
+		F613E3B025F9B61C1CAB05CA71EA6B22 /* Pods-RxGesture_iOS_Demo-RxSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxGesture_iOS_Demo-RxSwift.xcconfig"; path = "../Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.xcconfig"; sourceTree = "<group>"; };
+		F748183552175B762FB45CE31A2F53FC /* RxImagePickerDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxImagePickerDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxImagePickerDelegateProxy.swift; sourceTree = "<group>"; };
+		F788295A8CDD83CDBE32E83DFE9AF945 /* Pods-RxGesture_OSX_Demo-RxSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-RxGesture_OSX_Demo-RxSwift.modulemap"; sourceTree = "<group>"; };
+		F7C711FE0E199D267B5A4E427D1FF097 /* Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h"; sourceTree = "<group>"; };
+		F86FFCA66ED86F404880F6B796F87F05 /* Platform.Darwin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Darwin.swift; path = RxSwift/Platform/Platform.Darwin.swift; sourceTree = "<group>"; };
+		F8B7F8C036BA9171F3B199A086D94A88 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-RxGesture_iOS_Demo-RxSwift/Info.plist"; sourceTree = "<group>"; };
+		F90193FA637C5E3C76DCF1888950DB2C /* CombineLatest+CollectionType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CombineLatest+CollectionType.swift"; path = "RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift"; sourceTree = "<group>"; };
+		F9E699138D97A7B8FB51A1169458CC5B /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIRefreshControl+Rx.swift"; path = "RxCocoa/iOS/UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
+		FB5C6A9BAE45FFA2C75DC00EC9F9430F /* RefCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RefCount.swift; path = RxSwift/Observables/Implementations/RefCount.swift; sourceTree = "<group>"; };
+		FBC2B3604E156C2B39FB243BDBF5FBDC /* Pods-RxGesture_iOS_Demo-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RxGesture_iOS_Demo-umbrella.h"; sourceTree = "<group>"; };
+		FC3A97DF6DC20E8FA7115AF427A1FDA3 /* ScheduledDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledDisposable.swift; path = RxSwift/Disposables/ScheduledDisposable.swift; sourceTree = "<group>"; };
+		FD1A57E1C3EFB8080B64032CEBA6EEBA /* Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h"; path = "../Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h"; sourceTree = "<group>"; };
+		FDA6B4837F238135EDBB1FD219AC21E8 /* DisposeBag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBag.swift; path = RxSwift/Disposables/DisposeBag.swift; sourceTree = "<group>"; };
+		FDEB61CDD7978740C1A32E03C8A96C40 /* NSObject+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Rx.swift"; path = "RxCocoa/Common/Observables/NSObject+Rx.swift"; sourceTree = "<group>"; };
+		FDF08F5702058168441B64713EBBB29D /* MessageSentObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MessageSentObserver.swift; path = RxCocoa/Common/Observables/Implementations/MessageSentObserver.swift; sourceTree = "<group>"; };
+		FE1DCEC4B3D1DAFFC879A8BAB2E0B13C /* RxTextStorageDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTextStorageDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift; sourceTree = "<group>"; };
+		FE463EC4F9832060D985F73596AD1F98 /* Pods-RxGesture_iOS_Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RxGesture_iOS_Demo.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		195A0BC9DB44EB9697A3A61170725E9E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EE67AD4EF9BB7255F12A8E1ACF59F43 /* Cocoa.framework in Frameworks */,
+				9786556AA0483D04DD189DA66A8BB80C /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D670B044F667B3ABB1F4F604E72E380 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3DC2B0E80E48647EAF1B31B4333EE75D /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		39FD8BDAE7CFD0A590BD823D434061A3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				70767CE5090AA6DBA27615A97E5975B2 /* Cocoa.framework in Frameworks */,
+				9505DB71A910A7EA4A2BC2F348605F5A /* RxCocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		64F36D028C5B6F656BB7F9D8DE2CB4F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C4C8C36FB51CB1A5BEED5AAF41603DE2 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		955FA3AF691A7749E601D60274BF0519 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA139E952DF537781D766699B18CF101 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D874BCA6EE22322AFBF24C21422A224D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8E7CDAC755EB5A725153296B2E243630 /* Foundation.framework in Frameworks */,
+				BC48F2F74FDE1124DE6CA9C516A65F1E /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EFC5A0F424A48800CFC4B62F20F6A218 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BEE7FA81B3281D16D65348F06A05E393 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FE98B056871B5E87824C85DEFB8AB99A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				976CED50E8A41F564ABC9D9722A9B749 /* Foundation.framework in Frameworks */,
+				922DA1B8B35C278C5E7E06E5EC5D9D74 /* RxCocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		05974E627F79103F55BF0441A036DC2B /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				66A0A91B504135AF2AECC09049FA49A3 /* RxGesture */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		23B972FE2CA4CA82B850AB93E1490E98 /* Pods-RxGesture_OSX_Demo */ = {
+			isa = PBXGroup;
+			children = (
+				16B4F8DCF4CBA99637141D6CCD6AD93D /* Info.plist */,
+				7CDC591FE27EDF0166C359C990E9F4FA /* Pods-RxGesture_OSX_Demo.modulemap */,
+				6487EE29EEB4C56EED2333CF8AA5A55D /* Pods-RxGesture_OSX_Demo-acknowledgements.markdown */,
+				4B860A00382AC06FCFA0D8436A433574 /* Pods-RxGesture_OSX_Demo-acknowledgements.plist */,
+				8822B80A6A868B58E68512A9C1288FC8 /* Pods-RxGesture_OSX_Demo-dummy.m */,
+				17F984370AC1D8AD4B483F2E27E48830 /* Pods-RxGesture_OSX_Demo-frameworks.sh */,
+				A9446ADAA8A85A0CD4223AB8788DC5B6 /* Pods-RxGesture_OSX_Demo-resources.sh */,
+				8614B5BCCE597A517451A65FDCCF091B /* Pods-RxGesture_OSX_Demo-umbrella.h */,
+				969EF9A054D7A4FF9D52EC47F03E29BB /* Pods-RxGesture_OSX_Demo.debug.xcconfig */,
+				0BDB8D850932A64821E98B8CF500069E /* Pods-RxGesture_OSX_Demo.release.xcconfig */,
+			);
+			name = "Pods-RxGesture_OSX_Demo";
+			path = "Target Support Files/Pods-RxGesture_OSX_Demo";
+			sourceTree = "<group>";
+		};
+		2AD0AB82C8DCDE62D31342BBA1A5AB70 /* RxSwift */ = {
+			isa = PBXGroup;
+			children = (
+				37B0B8B080F1E6B923BEFBBF2DC5B11C /* AddRef.swift */,
+				920C57CA223DED99EA2B9BF7416E8664 /* Amb.swift */,
+				CAC81FC6ADF84CBF9D24DF18F08820B7 /* AnonymousDisposable.swift */,
+				06E8FE7D88F5AF65F3E6D57C39B12F30 /* AnonymousInvocable.swift */,
+				DFDC7869C929289A9CD3A92B63C692D1 /* AnonymousObservable.swift */,
+				BFFB4F5995EE9165EFF01A1B67E31329 /* AnonymousObserver.swift */,
+				F52B7AE23C229717D736C40F90B8D574 /* AnyObserver.swift */,
+				42922C460C6B4921C335F9A0AB78966B /* AsyncLock.swift */,
+				53E085BA27253B4EFEDD426526E4A96A /* Bag.swift */,
+				CA440FABEECC06934002C5B7DFFD96C3 /* BehaviorSubject.swift */,
+				6B52DF800B19E074DBC494C3F9A24063 /* BinaryDisposable.swift */,
+				226B5AC3BB6D95D9409C54D83CFBBDD4 /* BooleanDisposable.swift */,
+				9EBAC0789FA5CD3B9A97859B6633DD22 /* Buffer.swift */,
+				3871A7C8372F1322E306860D1430882B /* Cancelable.swift */,
+				C25308CFE7CECE3CF7E9AC0EBBD33AF9 /* Catch.swift */,
+				8FB5D2484879C5E0D0AC211D9FC603D5 /* CombineLatest.swift */,
+				8F0081C0EB913B4A12C9BA7F9E2C44CA /* CombineLatest+arity.swift */,
+				F90193FA637C5E3C76DCF1888950DB2C /* CombineLatest+CollectionType.swift */,
+				79EEA13950D3C7E26EA2C570F80B66C2 /* CompositeDisposable.swift */,
+				D9F0A2FEE585A9018680D5769208A755 /* Concat.swift */,
+				0047D7C07D4E7168D66A6B195B20AF58 /* ConcurrentDispatchQueueScheduler.swift */,
+				60F618BDF7BC2AC6CC2A49F4069E5944 /* ConcurrentMainScheduler.swift */,
+				10EAC6560D0E865FC286D0B2CEB21F8D /* ConnectableObservable.swift */,
+				4A2B40CC335CF4F90488701FB34D321D /* ConnectableObservableType.swift */,
+				2DE492C558DEBA31064661917BC71BE2 /* CurrentThreadScheduler.swift */,
+				DA6D897F503A3460A4E195622BACB277 /* Debug.swift */,
+				80464EA0B50C6A06A9C5061AA0E72B6E /* Deferred.swift */,
+				449F0019DD1F3E76574EB8C06356C328 /* DelaySubscription.swift */,
+				245AC5100739C5A8E44FBFE74CCCCC12 /* DispatchQueueSchedulerQOS.swift */,
+				19E010F7B88BB02E629463A73BA403E1 /* Disposable.swift */,
+				FDA6B4837F238135EDBB1FD219AC21E8 /* DisposeBag.swift */,
+				52DE9731E7AB29C0A4F4994F544D31EC /* DisposeBase.swift */,
+				41691D1578A4288F5D547260BF7422E4 /* DistinctUntilChanged.swift */,
+				02736A0824ED21A5F170A055AAC18B5E /* Do.swift */,
+				5FC278E77933E0D1F364DBD2B0A24180 /* ElementAt.swift */,
+				20587B5EBF4383E9A1A39FA525D0213B /* Empty.swift */,
+				C4122641759BCB149F3FCADD5C3268F7 /* Error.swift */,
+				C862CF3BD7290855D8AD7565CD8E2666 /* Errors.swift */,
+				3923CF81B57F0AB60F4DE73C980321DD /* Event.swift */,
+				E7731A4628E596D95ACD0AFE6EEBBA43 /* Filter.swift */,
+				A16B90AA9D152514C8ADF7451C1E90A4 /* Generate.swift */,
+				F60D78F33A072FBB5C97E5841B867C77 /* HistoricalScheduler.swift */,
+				DF3C7C58743CE4D5B3CC5515C5803942 /* HistoricalSchedulerTimeConverter.swift */,
+				C3923EA7357FC6223BC856AAE0F07580 /* ImmediateScheduler.swift */,
+				6FD15299911C10004D6C338D4883BEA6 /* ImmediateSchedulerType.swift */,
+				E1C544817D76E71D828DB3AE0EE5DFA3 /* InfiniteSequence.swift */,
+				B0105A3A5AF33D1CF3973AD0CF4AEB9C /* InvocableScheduledItem.swift */,
+				371997EFA02B3641F6F5DCA3462F231D /* InvocableType.swift */,
+				B746BEBFCD9CFA793E10E15D5E7B47D4 /* Just.swift */,
+				7C0C813650AFCAACE69C0BBAF5A9D251 /* Lock.swift */,
+				32333103781E0D7296DE45160EFFCF8A /* LockOwnerType.swift */,
+				33A5CCFF7C755C16BD3B5DB4FFE1F88D /* MainScheduler.swift */,
+				0905B95004BC92DB93247A62B00B3165 /* Map.swift */,
+				19A8502B4392E2C35D5ECF8145E781DC /* Merge.swift */,
+				C63811859DE646A04ED30107BC30950A /* Multicast.swift */,
+				714C5305FFAFC2F0793D969801E49179 /* NAryDisposable.swift */,
+				442E13A5AA3E5B956BF394857AB8456C /* Never.swift */,
+				1B3B751B0C5F626CB6E8FCE543FF5CF5 /* NopDisposable.swift */,
+				DA208E4396D571B3FF2C758E089F3C95 /* Observable.swift */,
+				B5B69664E4718AC7434121C115138625 /* Observable+Aggregate.swift */,
+				7E897AFACD8C7C5E2A001D27DE0B4618 /* Observable+Binding.swift */,
+				D91B8FB88CC735C3CC651A2DDAA219E5 /* Observable+Concurrency.swift */,
+				7968685A24D6C361EE9E76D7D17C454B /* Observable+Creation.swift */,
+				26F86A42574378E3C19BB20A1D4F6EE1 /* Observable+Debug.swift */,
+				ACDB236E3E70B35781D525D0318E5BB7 /* Observable+Extensions.swift */,
+				B94D6C7DD2DDCFDF47973632D61DB036 /* Observable+Multiple.swift */,
+				1371EDFFD119B102C16B66F5769F97F0 /* Observable+Single.swift */,
+				9DD6A6C23C63D4EB73064E6C68E20CD5 /* Observable+StandardSequenceOperators.swift */,
+				8806CC77B1040592A24B4F57B756C9AA /* Observable+Time.swift */,
+				867FB6D9CD5ADD06727AA1E89197078D /* ObservableConvertibleType.swift */,
+				D2AD1791E2917EF6FCE255F4894FA8AD /* ObservableType.swift */,
+				4B57D8DB71BDAB80D01EB772BB8B51EC /* ObserveOn.swift */,
+				D9688474E44B841F6129B4FAFFB2C565 /* ObserveOnSerialDispatchQueue.swift */,
+				D368C07F4793B141BBE46A5B8453B177 /* ObserverBase.swift */,
+				8D3FD3990B8A1E9548CB62F43886EADA /* ObserverType.swift */,
+				70C8BBEADC28B99A09E31C0BC5FE57FD /* OperationQueueScheduler.swift */,
+				F86FFCA66ED86F404880F6B796F87F05 /* Platform.Darwin.swift */,
+				DD670E6BA419147639CA62FC8C3CEDA5 /* Platform.Linux.swift */,
+				5F569847A7107D9276E4725C50D0916D /* PriorityQueue.swift */,
+				65D1EB659125EA3969D59014B9F4E1A4 /* Producer.swift */,
+				CA682272C2916EFCE819012AA8F6F4C6 /* PublishSubject.swift */,
+				3A847199C59581AE111ED00A7096043A /* Queue.swift */,
+				3E98F8FEECEC2DD9F966C9D3E8807071 /* Range.swift */,
+				A9BF5397CE64E09EB5C37D737FA40398 /* RecursiveScheduler.swift */,
+				3426C8436E0E44F1E70A1F7BC6D4BF63 /* Reduce.swift */,
+				FB5C6A9BAE45FFA2C75DC00EC9F9430F /* RefCount.swift */,
+				236983DA69E6A12F58775605239117DE /* RefCountDisposable.swift */,
+				6A7E2B288AEF9F04DA4D3DAF5B40E7F1 /* Repeat.swift */,
+				2C6AB6AEB9265AFCBF6B63FE10D75B45 /* ReplaySubject.swift */,
+				02A10A251161E99CA06BFBA191386FB4 /* RetryWhen.swift */,
+				CAAFF37D2CE77D76494B7F42ABF4792A /* Rx.swift */,
+				C64491ABA744A4BD99C4CB1D733B5DA3 /* RxMutableBox.swift */,
+				A995AACF502C4037D6FBC4C6112ED3BB /* Sample.swift */,
+				CB32E46DA8057A3A622F29F4500772A2 /* Scan.swift */,
+				FC3A97DF6DC20E8FA7115AF427A1FDA3 /* ScheduledDisposable.swift */,
+				419FD89DFCF42A6ADFE86D2D84B0EA46 /* ScheduledItem.swift */,
+				C7A741BE56BF66F4F2242CF3B34F1E6D /* ScheduledItemType.swift */,
+				573193BEB3DE9B1053800EFB15956A04 /* SchedulerServices+Emulation.swift */,
+				B594A1B0AF0D78EE827EB80F48CFEDDA /* SchedulerType.swift */,
+				666CEAE2C63819EF5FAC680D6243A456 /* Sequence.swift */,
+				036645378416B45CDB8CE10B07BE2213 /* SerialDispatchQueueScheduler.swift */,
+				6E0C7DD780E181D0F5EB28D77EDB199C /* SerialDisposable.swift */,
+				784DCD30FFABD70154CB39E13ADC428B /* ShareReplay1.swift */,
+				E145F810DEFF07BCE812538BFA651708 /* ShareReplay1WhileConnected.swift */,
+				06063B1BB0E18FA159CEC26B2275178D /* SingleAssignmentDisposable.swift */,
+				D94C88848C57B60ABE5E9867B1942078 /* SingleAsync.swift */,
+				7BCED313175C4FDCE4ABF2985910FD43 /* Sink.swift */,
+				C87E53818AF138ACF5D61B3D7D6E5274 /* Skip.swift */,
+				C3A0C86A2E540C585BD9EED8227FC082 /* SkipUntil.swift */,
+				223D2D9A89527A00F2C9592CF7FE7DFB /* SkipWhile.swift */,
+				B8A2FE6EDBAF67DE1651CFA7C30C0FA9 /* StableCompositeDisposable.swift */,
+				AE2DE95184E55408F0BFC4D170AF4C04 /* StartWith.swift */,
+				1541EFF54CE15FA4247A89DFB63268D8 /* String+Rx.swift */,
+				0FED2EC4C912C80F8F0A4FE9E545CB4E /* SubjectType.swift */,
+				A23025D7CBEA011BDDB9A5ECF666C1E8 /* SubscribeOn.swift */,
+				0C9289AF05996A8D7D12EAAF8869DBA2 /* SubscriptionDisposable.swift */,
+				85B26A5D41DBB998BC91E988B0B68FFF /* Switch.swift */,
+				EDBB3142C058BFF8F0B79E20C43D86F8 /* SynchronizedDisposeType.swift */,
+				3ADD86DB658ADA7B22F4A9E9D1DA25A8 /* SynchronizedOnType.swift */,
+				1A0E104B9153F15585DEC6956D497ACD /* SynchronizedSubscribeType.swift */,
+				2E09F8FD785663489A532E8A69164E9C /* SynchronizedUnsubscribeType.swift */,
+				AC31759D90FFBB778349105CD32B82A0 /* TailRecursiveSink.swift */,
+				032DD707905DA8D3C57277EF878F3240 /* Take.swift */,
+				C686CEFDB56AF5DFB18118006274FA02 /* TakeLast.swift */,
+				B54EEB7F3D9B9D4D2E5708405A57F65E /* TakeUntil.swift */,
+				D9CDE42D609590B6AA8AAD038BF20E21 /* TakeWhile.swift */,
+				880EC46B2EA4171F124091B6A8EEC9BE /* Throttle.swift */,
+				66A938D2640AAB94C102006232D3177B /* Timeout.swift */,
+				E4DCA1F1EC467C456DE2F6B57B5C35A6 /* Timer.swift */,
+				A3B83162A671B863092C509640455BB1 /* ToArray.swift */,
+				E34A5CB470BDF4610D116B4C6E6310CC /* Using.swift */,
+				8A47B3D1B773D68299EDABB9A4D54E96 /* Variable.swift */,
+				680753ED29B2B36844E7BF1D3EC725DE /* VirtualTimeConverterType.swift */,
+				D0E9E99E1790D8207298D944DDA5D4A2 /* VirtualTimeScheduler.swift */,
+				5FA6793E8440943D0A3CE5EC20DCC7FC /* Window.swift */,
+				0522CD8F0D5EA4DD356A6C34B68879AB /* WithLatestFrom.swift */,
+				C7E745319BCA81A3F171ED2C1DF23643 /* Zip.swift */,
+				713CD0C782C89D147C113A835FA5BD81 /* Zip+arity.swift */,
+				9D04517DD6AD2781E4CB927E673828D5 /* Zip+CollectionType.swift */,
+				771B9761981CCDDC31120956AFB6D6D5 /* Support Files */,
+			);
+			path = RxSwift;
+			sourceTree = "<group>";
+		};
+		38FFA225D5C51394D69115651C840EB4 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				8F6F72CD5B62C5C3465BA5E974A333C1 /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		66A0A91B504135AF2AECC09049FA49A3 /* RxGesture */ = {
+			isa = PBXGroup;
+			children = (
+				38FFA225D5C51394D69115651C840EB4 /* Pod */,
+				D20BEAC539F3FDAE5D9C0E1DD60CD4C4 /* Support Files */,
+			);
+			name = RxGesture;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		7213CFEC67C3B1D54FD43442BB4DD2F8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DBD5C714DE2DE3862DE6DD9ABF4BA0E0 /* Pods_RxGesture_iOS_Demo.framework */,
+				E0BD34020D1CF5E582610A08BF646C57 /* Pods_RxGesture_OSX_Demo.framework */,
+				1F19AA9E3785650C8EB42205C1EC4C29 /* RxCocoa.framework */,
+				8BC1538A9C562465360DC7DEE22C8AB0 /* RxGesture.framework */,
+				638D81BBC0A578B83C471D806B095768 /* RxSwift.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		74EBCCB5B3263EDA7A8F3F071712CAFD /* RxCocoa */ = {
+			isa = PBXGroup;
+			children = (
+				BC5384AAA357E269F58CCF248EF00C45 /* _RX.h */,
+				26AAE4981F2B2A0B345D49C6FFF3F191 /* _RX.m */,
+				1F4249BCB52EA315CF45C8AF750220C3 /* _RXDelegateProxy.h */,
+				49FBEB4800AA72C5B24F339E2CE4492A /* _RXDelegateProxy.m */,
+				EB39ED08E4C74181954C6B42D69F7FB7 /* _RXKVOObserver.h */,
+				8BF27BBCB2AAD5C679581C38EE2DC185 /* _RXKVOObserver.m */,
+				CB48DAD7D5163991153C05BD30040B6D /* _RXObjCRuntime.h */,
+				7CD8DFA3BDA378BDC5FF885379349130 /* _RXObjCRuntime.m */,
+				0AC1F877E92090E34F5CE2FB79F4629D /* CLLocationManager+Rx.swift */,
+				46DD1AB167A06B315005919A9BD6E8B4 /* ControlEvent.swift */,
+				E058D4EBE0ECDD108B8578F0C62D285A /* ControlEvent+Driver.swift */,
+				70AF53C1EA75011D56334E4AB4C72E91 /* ControlProperty.swift */,
+				4CDA9865788B870D2E0C9631A55AD2FC /* ControlProperty+Driver.swift */,
+				72A3310CDED6F0B1AC6B42A981CC578B /* ControlTarget.swift */,
+				8A4F910A4EF4840DF1A5FA245812BEB1 /* DeallocObservable.swift */,
+				2F709B0640631738B641635327262486 /* DelegateProxy.swift */,
+				D12DB9FC05ECEBD079763E18E22438A0 /* DelegateProxyType.swift */,
+				283198B3A1BC9C9C64AF8776DF9D8602 /* Driver.swift */,
+				DE379A21FCEBCEC0E0E426D9A123F760 /* Driver+Operators.swift */,
+				71AFAD963301C46BC7BC87E5B3D2F396 /* Driver+Operators+arity.swift */,
+				8A12623F1AB0752800B1DB10DF0417CF /* Driver+Subscription.swift */,
+				0278F3FA193A3C83B14B2E3F9ED87E2F /* ItemEvents.swift */,
+				9CE5313DC68E5A2FFE47DB9B6FC673E6 /* KVOObservable.swift */,
+				7D5E833F61266E85C52B9AFA5BDA55F0 /* KVOObserver.swift */,
+				3A8C262F7B62C28B263F49AACFDFAB2D /* KVORepresentable.swift */,
+				54133C9D54D6BD5ED81DAE23B47861CA /* KVORepresentable+CoreGraphics.swift */,
+				73E7917F369F21F0188070F597CDE8E6 /* KVORepresentable+Swift.swift */,
+				477AECB674F89335ACC974874BAC99FC /* Logging.swift */,
+				FDF08F5702058168441B64713EBBB29D /* MessageSentObserver.swift */,
+				018B5C8CFEFFB40F36662FA6FE88DAF1 /* NSButton+Rx.swift */,
+				95792EE983BD8CEAA248950D147179F7 /* NSControl+Rx.swift */,
+				1769EE025DD222C127D3D32B83C90BC0 /* NSImageView+Rx.swift */,
+				6399E931BEE7F5E5F5E04BAA0FC0DE34 /* NSLayoutConstraint+Rx.swift */,
+				777BF9DD554FFC95F2DFA576184620D8 /* NSNotificationCenter+Rx.swift */,
+				FDEB61CDD7978740C1A32E03C8A96C40 /* NSObject+Rx.swift */,
+				72024E9C45ED7ABA10282FBC2A8B6CC9 /* NSObject+Rx+KVORepresentable.swift */,
+				CCFDBBFF08F74F9511DF21F873EABE86 /* NSObject+Rx+RawRepresentable.swift */,
+				45EC70652ECAA2EB6A5CF971D91B21FF /* NSSlider+Rx.swift */,
+				3E46C8CA6BBF11ADED61F1E96D33D598 /* NSTextField+Rx.swift */,
+				3CB24918AFDA96F22951E15B52F35A8B /* NSTextStorage+Rx.swift */,
+				F5079F022D850EE97985FE670AE654D3 /* NSURLSession+Rx.swift */,
+				731149DD4332983A51195DAE8684A126 /* NSView+Rx.swift */,
+				2488AC35E99BBB5538B1BD95F7655E94 /* Observable+Bind.swift */,
+				2D0298A8428E79167215D2B8D70D16A5 /* ObservableConvertibleType+Driver.swift */,
+				3D1D85D88F45DA1940997764A3F22DA0 /* RxCLLocationManagerDelegateProxy.swift */,
+				89361C46E5D991265A6D4AECA7F2EAC4 /* RxCocoa.h */,
+				6E477EE3500BD6A016CE1951B989CF75 /* RxCocoa.swift */,
+				1E30F06ECF68CB0C48EA50C7EE7B2433 /* RxCollectionViewDataSourceProxy.swift */,
+				935D94469ED0B54EACC3A4C0F12B4646 /* RxCollectionViewDataSourceType.swift */,
+				8F88D395752826616234A8383CBDCA3D /* RxCollectionViewDelegateProxy.swift */,
+				AD57AA83FCA2E0F8E94E8CAFC455341C /* RxCollectionViewReactiveArrayDataSource.swift */,
+				F748183552175B762FB45CE31A2F53FC /* RxImagePickerDelegateProxy.swift */,
+				674637809C1638D6E46627D0A7363E43 /* RxScrollViewDelegateProxy.swift */,
+				1A2DA45028046C38FA03EA5A688E9AB4 /* RxSearchBarDelegateProxy.swift */,
+				65C5DCE08601B273DE0CF84D2AC1CA7D /* RxTableViewDataSourceProxy.swift */,
+				F2C2A9E19936B336BC0C7AE82D875826 /* RxTableViewDataSourceType.swift */,
+				5DC848B1D95281036D21CC324D052753 /* RxTableViewDelegateProxy.swift */,
+				D859CDF029BE59A16868AB0E614D41BB /* RxTableViewReactiveArrayDataSource.swift */,
+				DE4BF2809DFC533229426FC2B1D4AF91 /* RxTarget.swift */,
+				FE1DCEC4B3D1DAFFC879A8BAB2E0B13C /* RxTextStorageDelegateProxy.swift */,
+				06E0F99179E5CCB68C4721ECC9703E40 /* RxTextViewDelegateProxy.swift */,
+				3804ADE6554A61F56E0FCD797E6D3084 /* SectionedViewDataSourceType.swift */,
+				32DB01547F7219DFA5AFF3C2A27DC685 /* UIActivityIndicatorView+Rx.swift */,
+				9C6B788D60B66AC712BFEF712D9BE4B2 /* UIApplication+Rx.swift */,
+				F20316FCE33298DCDDE596E17F8ABF9B /* UIBarButtonItem+Rx.swift */,
+				CF5F9B539C916CEB13C073BD9B8706C9 /* UIBindingObserver.swift */,
+				83425313765F7ED109DC81D7BADC7B5A /* UIButton+Rx.swift */,
+				5C5A1CF70E522B6D4494C37B1C06F6D3 /* UICollectionView+Rx.swift */,
+				4B20F6146FF7DCA5A308859C677FAA81 /* UIControl+Rx.swift */,
+				5FA173D102727E0176EED982ADA11269 /* UIDatePicker+Rx.swift */,
+				8E3CECCCF5890CBE65780B3C8D44E2B1 /* UIGestureRecognizer+Rx.swift */,
+				2E17907AF176E8F017DBA35163551D37 /* UIImagePickerController+Rx.swift */,
+				3D5F0C9794F6E7E5EDE3E81BB3D21943 /* UIImageView+Rx.swift */,
+				AEDB7B436E22D693CB5360DB88CE7450 /* UILabel+Rx.swift */,
+				2576CF8363182027D6275CCCF79BFF09 /* UIProgressView+Rx.swift */,
+				F9E699138D97A7B8FB51A1169458CC5B /* UIRefreshControl+Rx.swift */,
+				3C99CE41C2C08F13D0EFB93F9F1AA297 /* UIScrollView+Rx.swift */,
+				DD0BF625CE8A09C228BDA4F907267DA2 /* UISearchBar+Rx.swift */,
+				9A2B0DA384E6A125B6430754BD9E8241 /* UISegmentedControl+Rx.swift */,
+				A7485BC75D5D55862531507EA811F6BA /* UISlider+Rx.swift */,
+				59638383E4045E9D58DD49A2FAD59AB2 /* UIStepper+Rx.swift */,
+				F0C4B9D95966A3DD638408DD2AC9A1C1 /* UISwitch+Rx.swift */,
+				937967AE1F14874EF338B1B8F57AA23B /* UITabBarItem+Rx.swift */,
+				BFA9612F9925AA3168C6A101B4C99CEF /* UITableView+Rx.swift */,
+				2CDEF5835D5C10A026F090259385CC21 /* UITextField+Rx.swift */,
+				6CD4E7DF61DAAA84A22AB05AD877367C /* UITextView+Rx.swift */,
+				2DF76949F9A826C7D066D20516A6268E /* UIView+Rx.swift */,
+				5B14A01C0088D795DF56061F4DA5C947 /* Variable+Driver.swift */,
+				E409A63713B84552678935C3B2FB066C /* Support Files */,
+			);
+			path = RxCocoa;
+			sourceTree = "<group>";
+		};
+		771B9761981CCDDC31120956AFB6D6D5 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				F8B7F8C036BA9171F3B199A086D94A88 /* Info.plist */,
+				A486D9E086D5087509C0FA917C16E181 /* Info.plist */,
+				521A807C1287A4736A5185E17EDD0D0F /* Pods-RxGesture_iOS_Demo-RxSwift.modulemap */,
+				F613E3B025F9B61C1CAB05CA71EA6B22 /* Pods-RxGesture_iOS_Demo-RxSwift.xcconfig */,
+				E592BE42F6C322EF48759A3D652B83BA /* Pods-RxGesture_iOS_Demo-RxSwift-dummy.m */,
+				784144428CC006C85BDB001BA7FC389B /* Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch */,
+				9EEA1B9C1EA4C125354E33390B6E85E6 /* Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h */,
+				F788295A8CDD83CDBE32E83DFE9AF945 /* Pods-RxGesture_OSX_Demo-RxSwift.modulemap */,
+				637B39D283F2B3C1CE39F900E3526F2C /* Pods-RxGesture_OSX_Demo-RxSwift.xcconfig */,
+				58ECEFE2F4CC184ABFE4A7BD4F63F568 /* Pods-RxGesture_OSX_Demo-RxSwift-dummy.m */,
+				E32F9EEBC2569CC8B22C59582C0E2D35 /* Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch */,
+				B8393E60BACCB4386FBDC6A62A9FA561 /* Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift";
+			sourceTree = "<group>";
+		};
+		7980E42EC0632C1655018D3F9FF4FF00 /* OSX */ = {
+			isa = PBXGroup;
+			children = (
+				2EA5E789256C909EFAB76C6238E9F905 /* NSGestureRecognizer+Rx.swift */,
+				754393E014D5DDCFD533E33A02544594 /* NSView+RxGesture.swift */,
+			);
+			path = OSX;
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				05974E627F79103F55BF0441A036DC2B /* Development Pods */,
+				B636038A1B7E8207534A0915F7BDD838 /* Frameworks */,
+				B70DB572A950F95B2749F85F2D2A4F31 /* Pods */,
+				7213CFEC67C3B1D54FD43442BB4DD2F8 /* Products */,
+				8CEC25C86E13D26170D9C7A385DC74C4 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		7F9306F3A8C6B18F1E89D3BFD4221F98 /* Pods-RxGesture_iOS_Demo */ = {
+			isa = PBXGroup;
+			children = (
+				4BA5080CDADDA1683B24B8F83BC42549 /* Info.plist */,
+				3C6C162A5F021385835632E3EDB7CC09 /* Pods-RxGesture_iOS_Demo.modulemap */,
+				6F0F0AF42A8ACC55406B4D1B3531B75C /* Pods-RxGesture_iOS_Demo-acknowledgements.markdown */,
+				93F4DB97B25A1296A903B4E94A63FB61 /* Pods-RxGesture_iOS_Demo-acknowledgements.plist */,
+				D72318DBF092553E249C7DEA4BD4BEA0 /* Pods-RxGesture_iOS_Demo-dummy.m */,
+				068C90A9229762E4F318F6CD34B2ECF5 /* Pods-RxGesture_iOS_Demo-frameworks.sh */,
+				7F4253EEA0015AD9E0F2EDD399E50ED6 /* Pods-RxGesture_iOS_Demo-resources.sh */,
+				FBC2B3604E156C2B39FB243BDBF5FBDC /* Pods-RxGesture_iOS_Demo-umbrella.h */,
+				97E089F34EA8E281F450990124ADE867 /* Pods-RxGesture_iOS_Demo.debug.xcconfig */,
+				FE463EC4F9832060D985F73596AD1F98 /* Pods-RxGesture_iOS_Demo.release.xcconfig */,
+			);
+			name = "Pods-RxGesture_iOS_Demo";
+			path = "Target Support Files/Pods-RxGesture_iOS_Demo";
+			sourceTree = "<group>";
+		};
+		8CEC25C86E13D26170D9C7A385DC74C4 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				7F9306F3A8C6B18F1E89D3BFD4221F98 /* Pods-RxGesture_iOS_Demo */,
+				23B972FE2CA4CA82B850AB93E1490E98 /* Pods-RxGesture_OSX_Demo */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		8F6F72CD5B62C5C3465BA5E974A333C1 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				383E8395E05602750FB92C87A2FDEB92 /* PanConfig.swift */,
+				6A0028F11D3A65960062328C /* TapConfig.swift */,
+				B938000B6A988DBB740EE2ED9F411571 /* RotateConfig.swift */,
+				B9D561015C9DD423C4695CE8F7CAE062 /* RxGesture.swift */,
+				8FC936CA127BE8A8C9DE8621E29025C9 /* iOS */,
+				7980E42EC0632C1655018D3F9FF4FF00 /* OSX */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		8FC936CA127BE8A8C9DE8621E29025C9 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				7F9DCD3DE6178587C27AF8D985383E08 /* UIView+RxGesture.swift */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		ACA5B0347B999FA572ABFFE737CA7AE5 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				94E8B074971AF38C0412AE173DB4552D /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		B22467B22BE2003C76E33AAA9CA35DE3 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				9D76728BF899DC869752E1AEF92F2522 /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
+		B636038A1B7E8207534A0915F7BDD838 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2F12CA77D6F2C4B36E0E751A89004250 /* RxCocoa.framework */,
+				90F97FBA1E50C1F43EAF8F3FAABD06AB /* RxSwift.framework */,
+				ACA5B0347B999FA572ABFFE737CA7AE5 /* iOS */,
+				B22467B22BE2003C76E33AAA9CA35DE3 /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B70DB572A950F95B2749F85F2D2A4F31 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				74EBCCB5B3263EDA7A8F3F071712CAFD /* RxCocoa */,
+				2AD0AB82C8DCDE62D31342BBA1A5AB70 /* RxSwift */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		D20BEAC539F3FDAE5D9C0E1DD60CD4C4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				634F4ECE00431123C06FD52C27501C64 /* Info.plist */,
+				8ABCA9D25D5ED7D25B873051B0E2BAB5 /* Info.plist */,
+				A7C8FF6E8BCA336FC4D4600B633328D2 /* Pods-RxGesture_iOS_Demo-RxGesture.modulemap */,
+				613CFDD9885D7CC54BC0041A8B2E9FE8 /* Pods-RxGesture_iOS_Demo-RxGesture.xcconfig */,
+				12B7233B7F267BF399EEED6714BCE42D /* Pods-RxGesture_iOS_Demo-RxGesture-dummy.m */,
+				D06B278E015398E2A3B9AB600AD200F1 /* Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch */,
+				FD1A57E1C3EFB8080B64032CEBA6EEBA /* Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h */,
+				4BE2E8575BDC4E03E951EAE8E023EA7B /* Pods-RxGesture_OSX_Demo-RxGesture.modulemap */,
+				82A721AFC5D1B757D919FEC84F9FEF74 /* Pods-RxGesture_OSX_Demo-RxGesture.xcconfig */,
+				6125CFE9D1577552DB75431F0817A868 /* Pods-RxGesture_OSX_Demo-RxGesture-dummy.m */,
+				C920A009DD877D098FB578E0E50EBFD6 /* Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch */,
+				F7C711FE0E199D267B5A4E427D1FF097 /* Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture";
+			sourceTree = "<group>";
+		};
+		E409A63713B84552678935C3B2FB066C /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				8267675773E498B54102DEDDB7B15C3E /* Info.plist */,
+				3E11B5F9407F2460BF507A031F543A31 /* Info.plist */,
+				A36FEB7BB3E2CD50B80A49D235925AF3 /* Pods-RxGesture_iOS_Demo-RxCocoa.modulemap */,
+				5F73DCC6D3F37BDB0EE4D0E020E4901D /* Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig */,
+				40731FA149D0C969EF2ACC2B814AAA39 /* Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m */,
+				F46C790F82DD42B1C1A090BF739A5BC5 /* Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch */,
+				D1541DD57D56EB09CEF071E8D1144E48 /* Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h */,
+				41262CC4216C45247331AC963D084351 /* Pods-RxGesture_OSX_Demo-RxCocoa.modulemap */,
+				AFE010FEC036F74911E6F9609402C03F /* Pods-RxGesture_OSX_Demo-RxCocoa.xcconfig */,
+				A0F993C4C6D6C90DB6204A41E10A910E /* Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m */,
+				DD67C1AB5326A859DF36368BF25BED53 /* Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch */,
+				810CDFDD1F29B38A57A777A0E34E51F3 /* Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0BBB68551EADF40B6394870505DC681B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				631A1DD20311EE54BC795DF915327298 /* _RX.h in Headers */,
+				13DAA72FFC4FEC8282FF159AF25E6C3C /* _RXDelegateProxy.h in Headers */,
+				24D7C3299CAA95F0C27AEB129A52E6F1 /* _RXKVOObserver.h in Headers */,
+				E2EB128A6BB718BA85611E62366C103B /* _RXObjCRuntime.h in Headers */,
+				CB761ED25DD8E01E6FE70D51365524DB /* Pods-RxGesture_iOS_Demo-RxCocoa-umbrella.h in Headers */,
+				4F30C3F0E32A967675B65D48BEAB63A4 /* RxCocoa.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		15A306E295D2367B200DE30C17839B09 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6B81B26818BFF79D9DE0909B20812BE6 /* Pods-RxGesture_iOS_Demo-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		205B1218645F50D5705293C3858B0490 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8CC9CB96DA7D4844F559C8C80088CD4 /* Pods-RxGesture_iOS_Demo-RxSwift-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		28DB94F701EECB69825350684A061A4F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				548BFBF4A1720DBCC0CDA20A3FC5F98E /* Pods-RxGesture_OSX_Demo-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		87D45D1CEF140D8687BAE10B04EF8E34 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				371DDD0CEF02B7460E792887795AE23C /* Pods-RxGesture_OSX_Demo-RxGesture-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6A9A933A8C1ECAD3DAFD2A489AD91AD /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB34D4B1C2FA534E510E5A6F93EC78C5 /* Pods-RxGesture_OSX_Demo-RxSwift-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E77B1193C404678CFF0564269C0E172E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				97C61F2EABC0E0556306C355CAF9A9DF /* Pods-RxGesture_iOS_Demo-RxGesture-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF3D61D08F8C97E0BBC4BB5E0115CC6C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA705E2E270100E5C40A74D6DF388F71 /* _RX.h in Headers */,
+				8E4DD36D597C752EBB6051DF7A6258A2 /* _RXDelegateProxy.h in Headers */,
+				DD3230BF944AB4C33C9399E620557C07 /* _RXKVOObserver.h in Headers */,
+				75DCFE5F338EA7396929204D17363C5F /* _RXObjCRuntime.h in Headers */,
+				1035B16F5AEAD95D6CE0D08BF42A068F /* Pods-RxGesture_OSX_Demo-RxCocoa-umbrella.h in Headers */,
+				E3C9982D23DD01F4E2153362830857AF /* RxCocoa.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		44538290913B42364D613A687800DA35 /* Pods-RxGesture_iOS_Demo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9D33872BAF4DC5FEC16683ED5494A07A /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo" */;
+			buildPhases = (
+				B3DB15563E7138CDB04ED4FEE30F9C0B /* Sources */,
+				955FA3AF691A7749E601D60274BF0519 /* Frameworks */,
+				15A306E295D2367B200DE30C17839B09 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8F7CCA301B616F7D8D91666A274C9185 /* PBXTargetDependency */,
+				D13E9BB839200D5CD261004AF41268D7 /* PBXTargetDependency */,
+				086E33B335E329AF6B3E4840A5067F05 /* PBXTargetDependency */,
+			);
+			name = "Pods-RxGesture_iOS_Demo";
+			productName = "Pods-RxGesture_iOS_Demo";
+			productReference = DBD5C714DE2DE3862DE6DD9ABF4BA0E0 /* Pods_RxGesture_iOS_Demo.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		614365A9E4840470AC452C75DD2858EC /* Pods-RxGesture_iOS_Demo-RxCocoa */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FFE6FFDA3FB700D8A1F431F6BE633F21 /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo-RxCocoa" */;
+			buildPhases = (
+				6AB24B3D46574156573F755E7B5C864F /* Sources */,
+				D874BCA6EE22322AFBF24C21422A224D /* Frameworks */,
+				0BBB68551EADF40B6394870505DC681B /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BC0F59D8DF7183BCA7D0C4C53E1BC98D /* PBXTargetDependency */,
+			);
+			name = "Pods-RxGesture_iOS_Demo-RxCocoa";
+			productName = "Pods-RxGesture_iOS_Demo-RxCocoa";
+			productReference = 1F19AA9E3785650C8EB42205C1EC4C29 /* RxCocoa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7C6A588762CF05921A56DE6635B89C5D /* Pods-RxGesture_OSX_Demo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 54F425529CB9BBD2E9204457CDBE6EBE /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo" */;
+			buildPhases = (
+				478E666AFFE284051B53DF3BCE11FCCD /* Sources */,
+				2D670B044F667B3ABB1F4F604E72E380 /* Frameworks */,
+				28DB94F701EECB69825350684A061A4F /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BC6C0360F2323A799BCA9C0911695482 /* PBXTargetDependency */,
+				9CA8E982B83600D9910D7D70B286823B /* PBXTargetDependency */,
+				C381F6C0D2BF123EA57219C3E98C84C4 /* PBXTargetDependency */,
+			);
+			name = "Pods-RxGesture_OSX_Demo";
+			productName = "Pods-RxGesture_OSX_Demo";
+			productReference = E0BD34020D1CF5E582610A08BF646C57 /* Pods_RxGesture_OSX_Demo.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9B0124864FA21CEC6CC3F9B3C55B6F65 /* Pods-RxGesture_OSX_Demo-RxCocoa */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF12F2A0C3DB5BC71502F2741134C221 /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo-RxCocoa" */;
+			buildPhases = (
+				14F184D4578891EF5AF48A72242696D6 /* Sources */,
+				195A0BC9DB44EB9697A3A61170725E9E /* Frameworks */,
+				EF3D61D08F8C97E0BBC4BB5E0115CC6C /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				847834D1DB009F49A71F9BE5F785B24B /* PBXTargetDependency */,
+			);
+			name = "Pods-RxGesture_OSX_Demo-RxCocoa";
+			productName = "Pods-RxGesture_OSX_Demo-RxCocoa";
+			productReference = 1F19AA9E3785650C8EB42205C1EC4C29 /* RxCocoa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9B27914C2D65E7BCA3CAB1D2365E645D /* Pods-RxGesture_iOS_Demo-RxSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C87E6CC572B39715080A5C3C3D52AA7F /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo-RxSwift" */;
+			buildPhases = (
+				D6DF8079D60BBBC0561EE11B941804DC /* Sources */,
+				EFC5A0F424A48800CFC4B62F20F6A218 /* Frameworks */,
+				205B1218645F50D5705293C3858B0490 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-RxGesture_iOS_Demo-RxSwift";
+			productName = "Pods-RxGesture_iOS_Demo-RxSwift";
+			productReference = 638D81BBC0A578B83C471D806B095768 /* RxSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D7D2E8A3E11B6A93694AEE6F34218DD3 /* Pods-RxGesture_OSX_Demo-RxSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D7B567D2F85E5F4E1BEA8ECF23B62CC /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo-RxSwift" */;
+			buildPhases = (
+				D3F77243EF52EC5DD00A359FD77D68F2 /* Sources */,
+				64F36D028C5B6F656BB7F9D8DE2CB4F4 /* Frameworks */,
+				D6A9A933A8C1ECAD3DAFD2A489AD91AD /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-RxGesture_OSX_Demo-RxSwift";
+			productName = "Pods-RxGesture_OSX_Demo-RxSwift";
+			productReference = 638D81BBC0A578B83C471D806B095768 /* RxSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		FEC7E09BE7C35F9F8658D953E429D451 /* Pods-RxGesture_OSX_Demo-RxGesture */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2A940E69BC5371EEA2C7CCEACA25AB6C /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo-RxGesture" */;
+			buildPhases = (
+				40278FBAB194366C10D902746F0AEC7B /* Sources */,
+				39FD8BDAE7CFD0A590BD823D434061A3 /* Frameworks */,
+				87D45D1CEF140D8687BAE10B04EF8E34 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				37DE1A019926E248B0F8C4BFA0957231 /* PBXTargetDependency */,
+			);
+			name = "Pods-RxGesture_OSX_Demo-RxGesture";
+			productName = "Pods-RxGesture_OSX_Demo-RxGesture";
+			productReference = 8BC1538A9C562465360DC7DEE22C8AB0 /* RxGesture.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		FF39F572578F134BF8414A8D27FD3729 /* Pods-RxGesture_iOS_Demo-RxGesture */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77A85EF82F6A93E9EBFCD97A800D30F0 /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo-RxGesture" */;
+			buildPhases = (
+				BD2F6DF7E83A8F2FC1A44E6FED0C1B6A /* Sources */,
+				FE98B056871B5E87824C85DEFB8AB99A /* Frameworks */,
+				E77B1193C404678CFF0564269C0E172E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A8B8C84A3664BFD488DDAC8393D52116 /* PBXTargetDependency */,
+			);
+			name = "Pods-RxGesture_iOS_Demo-RxGesture";
+			productName = "Pods-RxGesture_iOS_Demo-RxGesture";
+			productReference = 8BC1538A9C562465360DC7DEE22C8AB0 /* RxGesture.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0700;
+			};
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 7213CFEC67C3B1D54FD43442BB4DD2F8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				44538290913B42364D613A687800DA35 /* Pods-RxGesture_iOS_Demo */,
+				614365A9E4840470AC452C75DD2858EC /* Pods-RxGesture_iOS_Demo-RxCocoa */,
+				FF39F572578F134BF8414A8D27FD3729 /* Pods-RxGesture_iOS_Demo-RxGesture */,
+				9B27914C2D65E7BCA3CAB1D2365E645D /* Pods-RxGesture_iOS_Demo-RxSwift */,
+				7C6A588762CF05921A56DE6635B89C5D /* Pods-RxGesture_OSX_Demo */,
+				9B0124864FA21CEC6CC3F9B3C55B6F65 /* Pods-RxGesture_OSX_Demo-RxCocoa */,
+				FEC7E09BE7C35F9F8658D953E429D451 /* Pods-RxGesture_OSX_Demo-RxGesture */,
+				D7D2E8A3E11B6A93694AEE6F34218DD3 /* Pods-RxGesture_OSX_Demo-RxSwift */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		14F184D4578891EF5AF48A72242696D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A653AC721AB76BD247BD21ACB54FC4E1 /* _RX.m in Sources */,
+				303BA170CFDE25D980D0B4DA54BDAB58 /* _RXDelegateProxy.m in Sources */,
+				EB2A84A5948EBF2DF07E8C6C1535F69C /* _RXKVOObserver.m in Sources */,
+				20C06CF74646A61B0C5EFF0F626C346F /* _RXObjCRuntime.m in Sources */,
+				752964FCFB788000B79D21627D4D737E /* CLLocationManager+Rx.swift in Sources */,
+				C2C7F0554D20A58F6D5E3657640E6745 /* ControlEvent+Driver.swift in Sources */,
+				26FDC717A2FA97E2A878CCE2092994BC /* ControlEvent.swift in Sources */,
+				0AA76BFB01DDC6C4DC5206BAAFB02AB5 /* ControlProperty+Driver.swift in Sources */,
+				E04FB4107DD3A5DCF1062A8E82ACA4F3 /* ControlProperty.swift in Sources */,
+				CADA73E1D18C4B1507FA15CE4A973324 /* ControlTarget.swift in Sources */,
+				57E883ABEAA37C1D5A61A17EDF8C5CF6 /* DeallocObservable.swift in Sources */,
+				F06E6FB5C72FA43030789513F4821926 /* DelegateProxy.swift in Sources */,
+				00F8A441477F0B251EE61CF7A98BED9B /* DelegateProxyType.swift in Sources */,
+				6C8881718CC15265D09C41CBB10B7E9E /* Driver+Operators+arity.swift in Sources */,
+				4BBFDC66B5D6EDBA302DFCCD0A31BFD5 /* Driver+Operators.swift in Sources */,
+				847D340E4481EB953B56E987A8863B62 /* Driver+Subscription.swift in Sources */,
+				536AE1D5281359DEF6F7890B09F1B40E /* Driver.swift in Sources */,
+				D85E2176535BD6BEB9DC135A7F8B1C18 /* KVOObservable.swift in Sources */,
+				91721397EC011682D479904C93C12753 /* KVOObserver.swift in Sources */,
+				2A61A0A93B128DEAA575ED886869D432 /* KVORepresentable+CoreGraphics.swift in Sources */,
+				57A44A6F3687891BCF5CB0CDB1B1B7B7 /* KVORepresentable+Swift.swift in Sources */,
+				2A1CD5FC5B38CC1653414E3AAA7A02B3 /* KVORepresentable.swift in Sources */,
+				9DDCA6731F75967C99C394CD687BA328 /* Logging.swift in Sources */,
+				FE6A06583DCAD5929380A73780693C1D /* MessageSentObserver.swift in Sources */,
+				2D92995D37170EFA5808AEF0155AB522 /* NSButton+Rx.swift in Sources */,
+				CBA8DBF45CDA4CFC978E23AB26A807E8 /* NSControl+Rx.swift in Sources */,
+				1E5FB7BCA876FA81FC36980DBF774826 /* NSImageView+Rx.swift in Sources */,
+				4F2D991B08E329A0337FB73CACB68194 /* NSLayoutConstraint+Rx.swift in Sources */,
+				732C1BA4FEAEBF02986DD3EE64224F80 /* NSNotificationCenter+Rx.swift in Sources */,
+				FBE1FA148B8A7875D8A705D0C9804762 /* NSObject+Rx+KVORepresentable.swift in Sources */,
+				D92B1754DDCAEF92566DAC3592014D73 /* NSObject+Rx+RawRepresentable.swift in Sources */,
+				2DDA95E846507AC77F703CA51635C9B7 /* NSObject+Rx.swift in Sources */,
+				FA9E64EF1F16C9A75321D321AB87C4A4 /* NSSlider+Rx.swift in Sources */,
+				0B4B7D83E73B0AA1350996A9C1A69BE3 /* NSTextField+Rx.swift in Sources */,
+				3B60F86E57C6E0B5EB1C16329497CA38 /* NSURLSession+Rx.swift in Sources */,
+				2FE889C233DB3D6EE9B795A6B49DEBF2 /* NSView+Rx.swift in Sources */,
+				CF029F863E85E7C03591D4210989B647 /* Observable+Bind.swift in Sources */,
+				4E118E5BBB86F4E3D5BE4404D82BE6D0 /* ObservableConvertibleType+Driver.swift in Sources */,
+				72C524E7B71E56E69737978A30762BD0 /* Pods-RxGesture_OSX_Demo-RxCocoa-dummy.m in Sources */,
+				455E80A5EA99580469518024869EA1AA /* RxCLLocationManagerDelegateProxy.swift in Sources */,
+				B77B250A5C4091D9437711ACFFE1A60B /* RxCocoa.swift in Sources */,
+				E5AAEEC20D987248D63ADAEC556054C8 /* RxTarget.swift in Sources */,
+				A1558AC0EC6057A3B2E5C0A902FC1623 /* SectionedViewDataSourceType.swift in Sources */,
+				4243ABB4D6D5A1F0E3F004DD880FCC0B /* UIBindingObserver.swift in Sources */,
+				615B0141A00A2139932548F59332833A /* Variable+Driver.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		40278FBAB194366C10D902746F0AEC7B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0F6D25550D0AB1122728E0E202E9B2F /* NSGestureRecognizer+Rx.swift in Sources */,
+				A8D37F4EA054BE484E3BB6DC1A471493 /* NSView+RxGesture.swift in Sources */,
+				DCA27732462FA9070AE710D9A361ADA0 /* PanConfig.swift in Sources */,
+				0CE1F2ABB8602030A1F03084D04D59C5 /* Pods-RxGesture_OSX_Demo-RxGesture-dummy.m in Sources */,
+				72D0FD90034EB33EA0C92656D7074D46 /* RotateConfig.swift in Sources */,
+				6A0028F41D3A66070062328C /* TapConfig.swift in Sources */,
+				EB04FF1B2FE87A99D524B3A353ADC3EA /* RxGesture.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		478E666AFFE284051B53DF3BCE11FCCD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				153315CB7CE0328B96834073C4C53691 /* Pods-RxGesture_OSX_Demo-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6AB24B3D46574156573F755E7B5C864F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E60ED422014F151D85A4DE0D0090BED2 /* _RX.m in Sources */,
+				A1435F6083BF431922428FD10EC7A363 /* _RXDelegateProxy.m in Sources */,
+				A251D2B4AEC83C9A367126EC5FBD3154 /* _RXKVOObserver.m in Sources */,
+				9FE76B6763DDF6DDE5A227F3FAE42324 /* _RXObjCRuntime.m in Sources */,
+				D2CB38767A2E8CD22E0C3F424ACDC178 /* CLLocationManager+Rx.swift in Sources */,
+				7E1DAD3A8BF695335D0FCEC77C7B2629 /* ControlEvent+Driver.swift in Sources */,
+				48EB43C260994DB39FF711D96FB30B66 /* ControlEvent.swift in Sources */,
+				7D3EFAC4F3A7F0FFD1AF360CCFE9CD71 /* ControlProperty+Driver.swift in Sources */,
+				69AC08DF9FDE31998C7869EBAF62B3AF /* ControlProperty.swift in Sources */,
+				9A72425633B1074724BE4AD9E253486F /* ControlTarget.swift in Sources */,
+				1B4A8D83F816BC448322BC0057DAA019 /* DeallocObservable.swift in Sources */,
+				05B217FDEBD05EAF43320C9D44E5D002 /* DelegateProxy.swift in Sources */,
+				A741711B1571F9AEDC76DF57CDCC049D /* DelegateProxyType.swift in Sources */,
+				1897D796678C177CDE2943A913694DA1 /* Driver+Operators+arity.swift in Sources */,
+				DDF30573D7664E73624011D0DAD860C5 /* Driver+Operators.swift in Sources */,
+				1DEA721BCEC873F79234C5E63F2548B8 /* Driver+Subscription.swift in Sources */,
+				BCDAA38E7E8D4116EA76D257BC319C4D /* Driver.swift in Sources */,
+				83C2F4F5EF675EAC0897B942201FF004 /* ItemEvents.swift in Sources */,
+				541C9D6E1A995FF9AC9ADD3FB982BCE3 /* KVOObservable.swift in Sources */,
+				581AF6CF184D616CB20A4BF3484367C7 /* KVOObserver.swift in Sources */,
+				B32070E942F1B441075C288B6D0ED075 /* KVORepresentable+CoreGraphics.swift in Sources */,
+				BFCDB1F0CB2317AA6C5C494CE54FE8AA /* KVORepresentable+Swift.swift in Sources */,
+				AC8E5C01404D499F26CD4C999E341E12 /* KVORepresentable.swift in Sources */,
+				42656EE65DDFF8396FEC9E28CDD0F922 /* Logging.swift in Sources */,
+				F86837682196263E9D5F287348EB7B59 /* MessageSentObserver.swift in Sources */,
+				BF180276153CFFF40164206E6A3BEDFE /* NSLayoutConstraint+Rx.swift in Sources */,
+				BA8B75DCD8B33C4AD231FA051BF3EFC7 /* NSNotificationCenter+Rx.swift in Sources */,
+				5F9E2936986466A91E3AA1E822C6D3F5 /* NSObject+Rx+KVORepresentable.swift in Sources */,
+				0F0D9C24C0E44E57008ED781A6A9540A /* NSObject+Rx+RawRepresentable.swift in Sources */,
+				421A99241D4A19BC0384E070B6F733C6 /* NSObject+Rx.swift in Sources */,
+				F300A6D9B9E5AE90DC83258DC5E63E53 /* NSTextStorage+Rx.swift in Sources */,
+				A58ACD233E056D2610BCF047FC636DD1 /* NSURLSession+Rx.swift in Sources */,
+				01E61E8DC081EA6C0009BBD7057D29C1 /* Observable+Bind.swift in Sources */,
+				4CF423794EC5A22C04F574B184D00299 /* ObservableConvertibleType+Driver.swift in Sources */,
+				BC99BB8FACD40E788CCAA7BDFBC77498 /* Pods-RxGesture_iOS_Demo-RxCocoa-dummy.m in Sources */,
+				F0E9F066503AC19C46BC1AA084BAFD15 /* RxCLLocationManagerDelegateProxy.swift in Sources */,
+				4E23CD6B7C23EABCF587E3A2E346290F /* RxCocoa.swift in Sources */,
+				BD376A3A84020AEE9C9152B28EC0E881 /* RxCollectionViewDataSourceProxy.swift in Sources */,
+				9EFC8B35852B90A6EC3A9D47486CA105 /* RxCollectionViewDataSourceType.swift in Sources */,
+				38B3C9CDAAF67C93B531598DCF0ECC15 /* RxCollectionViewDelegateProxy.swift in Sources */,
+				E8501FA1970C16E7C772C02D8159FC00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */,
+				5BAD48CCE78D0D04C2596297ED9F3F97 /* RxImagePickerDelegateProxy.swift in Sources */,
+				413C9E34B2F9D258BD62EDE945AEBE45 /* RxScrollViewDelegateProxy.swift in Sources */,
+				23978FC6352310883C0A2876EB707671 /* RxSearchBarDelegateProxy.swift in Sources */,
+				C4C47BAFEE1709C11AB5145DCF02D960 /* RxTableViewDataSourceProxy.swift in Sources */,
+				05BD51B2599DFF8C9D77DF9CCAB2F8CD /* RxTableViewDataSourceType.swift in Sources */,
+				491AEE4FE3195E5CA1225E6294EE1D43 /* RxTableViewDelegateProxy.swift in Sources */,
+				260BDDD7A70035E73256485415DEEAFF /* RxTableViewReactiveArrayDataSource.swift in Sources */,
+				18570A91E717C6ACB651EF74D1504147 /* RxTarget.swift in Sources */,
+				AF308452C9E3E4F62252D19FBD918CA7 /* RxTextStorageDelegateProxy.swift in Sources */,
+				0CBCDC693500CA15D126A035DB4D4367 /* RxTextViewDelegateProxy.swift in Sources */,
+				9A67BEAAD395C1FAB9421B85C177D655 /* SectionedViewDataSourceType.swift in Sources */,
+				BD94DC753DE37948A6725AFEB246FC78 /* UIActivityIndicatorView+Rx.swift in Sources */,
+				3D98B80CA17B506B8C1B759D6A10E049 /* UIApplication+Rx.swift in Sources */,
+				2B0D27F069E8F0E701A6C9CDD3F57504 /* UIBarButtonItem+Rx.swift in Sources */,
+				C4E0857D9EDB53394B79170F060B50DD /* UIBindingObserver.swift in Sources */,
+				DFF7AC2C01AE58822F964F3F439067AA /* UIButton+Rx.swift in Sources */,
+				23E941CEBFF4F79C8A915B8ED8FD1827 /* UICollectionView+Rx.swift in Sources */,
+				D14C2BC5CCDB880C6B15F4858C458EB1 /* UIControl+Rx.swift in Sources */,
+				B8FD0CAA10337CBD9FC73B16905717B6 /* UIDatePicker+Rx.swift in Sources */,
+				BF46C30F6DA5B7E88423642828CEEDF3 /* UIGestureRecognizer+Rx.swift in Sources */,
+				C81E9FE86F69EE1D3FAF2AC827103164 /* UIImagePickerController+Rx.swift in Sources */,
+				666EC55287F6C67AE52B6B460EAA059D /* UIImageView+Rx.swift in Sources */,
+				0C47F7A3A711DEF2852287E958912400 /* UILabel+Rx.swift in Sources */,
+				0305F269FD99A7E9B15020CDE7EC04AC /* UIProgressView+Rx.swift in Sources */,
+				8DA8A901EE6CDF0AF1D59CC4EEC1F3C4 /* UIRefreshControl+Rx.swift in Sources */,
+				08D2BF0199EBBCEC535A63481EEA6E5E /* UIScrollView+Rx.swift in Sources */,
+				8E73D62412624AB799DE8F75CC24F0F9 /* UISearchBar+Rx.swift in Sources */,
+				07537B3412788F76A1CADAE162264580 /* UISegmentedControl+Rx.swift in Sources */,
+				FCCAD7210551E7E315057FE92B71710C /* UISlider+Rx.swift in Sources */,
+				A6985271C67D3D39671F6594CC636975 /* UIStepper+Rx.swift in Sources */,
+				73F6711DED2B6CDFA88C34BBB7283730 /* UISwitch+Rx.swift in Sources */,
+				1A6B5613B12EDBA017A9204D949A4D2A /* UITabBarItem+Rx.swift in Sources */,
+				4ADCF9F5D8C0D7D8D78504E013A3F8F8 /* UITableView+Rx.swift in Sources */,
+				789C95EFBA949A2C03982A2E9D62E0DD /* UITextField+Rx.swift in Sources */,
+				54D5A7B71E1199F308A12D92BD355DD0 /* UITextView+Rx.swift in Sources */,
+				860D3C64CC7EDA6718F7158ED0F613DB /* UIView+Rx.swift in Sources */,
+				D4471926F81D20E92AAC8F5D7966020C /* Variable+Driver.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B3DB15563E7138CDB04ED4FEE30F9C0B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15B5E4C3EFE2725A54E98104C2781351 /* Pods-RxGesture_iOS_Demo-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BD2F6DF7E83A8F2FC1A44E6FED0C1B6A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A01F5D8032F07A5A0D80DCEA17D7282 /* PanConfig.swift in Sources */,
+				6A0028F31D3A66050062328C /* TapConfig.swift in Sources */,
+				14E592CECFBE338044522B24E1481FE6 /* Pods-RxGesture_iOS_Demo-RxGesture-dummy.m in Sources */,
+				7783C8B43B0F83A3E122DF1748EC8CAB /* RotateConfig.swift in Sources */,
+				1C2DB5C4B575F0B74C596E23A59C934A /* RxGesture.swift in Sources */,
+				8526D54EBF04F2654F48E763F88A8142 /* UIView+RxGesture.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D3F77243EF52EC5DD00A359FD77D68F2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE5FA788DE0D4E7D6D60BA1CEDEEFB62 /* AddRef.swift in Sources */,
+				CE245DA8E68C8D112CEF7E56A751CD90 /* Amb.swift in Sources */,
+				CE528D85B9B645900D89164F2722CFF0 /* AnonymousDisposable.swift in Sources */,
+				AB11A18FBAC250B26EE7C7A08E3B8813 /* AnonymousInvocable.swift in Sources */,
+				C317D014A7DBD70F5AB21D95B1C1DE85 /* AnonymousObservable.swift in Sources */,
+				077B2088D0B86F82BDEBA1EBFAE9669A /* AnonymousObserver.swift in Sources */,
+				7434BE3361F7A52BAE1FC831D881C933 /* AnyObserver.swift in Sources */,
+				DA600661558FFEB04BB1DA6E56D7BA9A /* AsyncLock.swift in Sources */,
+				659676DA59F72833BBCCB9853A143C7E /* Bag.swift in Sources */,
+				4A6886197AD7FBF1B3FE9A919B412C2A /* BehaviorSubject.swift in Sources */,
+				6956E7A76E55AB0986EE76E8CDF2AC47 /* BinaryDisposable.swift in Sources */,
+				71BC036D660D42931AC03ABF46519321 /* BooleanDisposable.swift in Sources */,
+				DF644BC19728B14C164A989F9C370CDC /* Buffer.swift in Sources */,
+				D56B102D752D618E23E784BAC7AFAA95 /* Cancelable.swift in Sources */,
+				70E1CCCB0F08BF258F53C425F111D784 /* Catch.swift in Sources */,
+				3EE7A1AD2ACB8E5B50341976B1316CAB /* CombineLatest+arity.swift in Sources */,
+				68FDD0E090F8DA37A3283ABA5E5DEF50 /* CombineLatest+CollectionType.swift in Sources */,
+				55FD4EC3DFD48707D686FB0E30E9CFEB /* CombineLatest.swift in Sources */,
+				BCC627EFA42BCBDD8FC0B3721D139E61 /* CompositeDisposable.swift in Sources */,
+				C04B8E1CB28327C6E3329D5C505F1E5F /* Concat.swift in Sources */,
+				6FC7A3AACED3A13E19B113FBFFE5F6A6 /* ConcurrentDispatchQueueScheduler.swift in Sources */,
+				F150F627FA22644A5A75B5B046FF3B6B /* ConcurrentMainScheduler.swift in Sources */,
+				9C03589B9228FF4EBFA9A3F7C7453EBC /* ConnectableObservable.swift in Sources */,
+				87106C3E8834791259A7E930EF519CD2 /* ConnectableObservableType.swift in Sources */,
+				D6B1F7F217F77E9186E76925C6CE6D3E /* CurrentThreadScheduler.swift in Sources */,
+				750B5432B0FF3138009F3EEA57AFE84E /* Debug.swift in Sources */,
+				E49783BB78FFE662360F74DB16C026FC /* Deferred.swift in Sources */,
+				6982B8E4C6FF27973BC4186FA1B03D23 /* DelaySubscription.swift in Sources */,
+				FD3053D58B4B90A6385906722E65D5E5 /* DispatchQueueSchedulerQOS.swift in Sources */,
+				14F0CB6A70A3D96F1C4BE2E5CCF9C2C4 /* Disposable.swift in Sources */,
+				758C1D78FBE53E84387DB6ADD0076CEF /* DisposeBag.swift in Sources */,
+				593F579D1BAF6BE32C0C8EE70F88A84B /* DisposeBase.swift in Sources */,
+				57441D145F1BBDF326D2F35A2E722FEA /* DistinctUntilChanged.swift in Sources */,
+				9F217F9C4E260A51EC69B826D1ECAD47 /* Do.swift in Sources */,
+				9B35043F7EA722855C342069EA69F80C /* ElementAt.swift in Sources */,
+				FD62880460C77E0A9BAF5FCF3EB7E4CA /* Empty.swift in Sources */,
+				5CD5BCA415EF28EF307CECBA0621EAC6 /* Error.swift in Sources */,
+				99B67115B280334F9D6E4561C6A2B9B1 /* Errors.swift in Sources */,
+				83E43C0E90CB742D1536BB8DA28FC055 /* Event.swift in Sources */,
+				1F76BDB26F35646A511521BFC163D808 /* Filter.swift in Sources */,
+				F7D7F0E69267A2EC33065AC12526C089 /* Generate.swift in Sources */,
+				7A6AB5F92240D1411B8C16AA3601EC2D /* HistoricalScheduler.swift in Sources */,
+				FC726DC55B0CC8247FECC7370424A3AE /* HistoricalSchedulerTimeConverter.swift in Sources */,
+				4532A8C74BD6D971D4ABCC991604D0B7 /* ImmediateScheduler.swift in Sources */,
+				E4F716E7B90B006A0A58F63CC6266D4D /* ImmediateSchedulerType.swift in Sources */,
+				4FD268B8698165B5E6A0F33480CBBC33 /* InfiniteSequence.swift in Sources */,
+				4E0B27C110E6EBE3540BC9CDE16DAEBD /* InvocableScheduledItem.swift in Sources */,
+				F61BF2C739E958D5E5D08C55E5EAF0F8 /* InvocableType.swift in Sources */,
+				90FC859F6BEF7CA9F25A3F57BEF925A5 /* Just.swift in Sources */,
+				27319C465E633116B267CA247084A624 /* Lock.swift in Sources */,
+				6CAB49D89624A04E4152A06D8E5AC124 /* LockOwnerType.swift in Sources */,
+				B3A94B8B6CFF3BB21B54E37E9A3CC829 /* MainScheduler.swift in Sources */,
+				09DE898823F74CB06BE5792F0CC7D1B6 /* Map.swift in Sources */,
+				5B3561537F5610E105E39CD7552E1426 /* Merge.swift in Sources */,
+				05C4DDCFD41B0362192795C66D54E2D4 /* Multicast.swift in Sources */,
+				9B9B0018B167196825E5FC64DF2C60D9 /* NAryDisposable.swift in Sources */,
+				E72B0C0D6CBD12E8A5F21B72CDDD7203 /* Never.swift in Sources */,
+				93CBC8B4B0B4A92CC028405BADDC7BB7 /* NopDisposable.swift in Sources */,
+				9C6F3D50FF5622B23E76113A13182DB2 /* Observable+Aggregate.swift in Sources */,
+				3C7AC628FB1EABCBB60604EF5F9E9DDB /* Observable+Binding.swift in Sources */,
+				74B6F38577B25B297F2010325DC77DD3 /* Observable+Concurrency.swift in Sources */,
+				100E0FBCFBCB8BE4FEBE0CC293730203 /* Observable+Creation.swift in Sources */,
+				32CC0E764B6FDD289813E6A11F422622 /* Observable+Debug.swift in Sources */,
+				C6B15BFB809D0286742C1447591A61D9 /* Observable+Extensions.swift in Sources */,
+				CDF9FEDEA4D51C517D572E46FBC8621C /* Observable+Multiple.swift in Sources */,
+				6744289BF897F4D0525E1819B31C7CA9 /* Observable+Single.swift in Sources */,
+				56FD49EF04E53934E3A49F07237ACAE7 /* Observable+StandardSequenceOperators.swift in Sources */,
+				B03014AE13A5E078B02A052A0FBE9A20 /* Observable+Time.swift in Sources */,
+				C72E3C80BC9C48E5640A4CCEF40949A5 /* Observable.swift in Sources */,
+				A54A1ECD706A5EA99BE7D81EAA32A26F /* ObservableConvertibleType.swift in Sources */,
+				AA5369D0171DDDBBE6116FCB66834C5D /* ObservableType.swift in Sources */,
+				8E9D487DFEA8015CA9E7123698C10196 /* ObserveOn.swift in Sources */,
+				9F22B19D087C06C030D8F2540356AA99 /* ObserveOnSerialDispatchQueue.swift in Sources */,
+				270525BB31443A4DDFBC264C35F83AA2 /* ObserverBase.swift in Sources */,
+				2E4A651B3831DC039C0967839B8DE460 /* ObserverType.swift in Sources */,
+				DAC73301778EBDD3A376AB81B1706375 /* OperationQueueScheduler.swift in Sources */,
+				51C2DEE2E38271654A307DB0A57826FB /* Platform.Darwin.swift in Sources */,
+				92A2FEAAF18E42ADF6CC190BFA27217D /* Platform.Linux.swift in Sources */,
+				1514F07E372FBDC4AC1D948329D062B3 /* Pods-RxGesture_OSX_Demo-RxSwift-dummy.m in Sources */,
+				67CAC0F262FD2A9FCA59C6463798FCAF /* PriorityQueue.swift in Sources */,
+				B5E007C19DC437B74F3B459606D3B040 /* Producer.swift in Sources */,
+				4BCCA5EA84D6D228F84102A8C62BC93A /* PublishSubject.swift in Sources */,
+				58F145B976F3F9425E87313ECFD8E02E /* Queue.swift in Sources */,
+				E3E5A164068D5B2AAA03B81990810232 /* Range.swift in Sources */,
+				6D2AD61B12BFF5101ACA654F7586EFBD /* RecursiveScheduler.swift in Sources */,
+				D1FE0E16B1F05DFE7771055D52939287 /* Reduce.swift in Sources */,
+				974A7B9743248803127142B96776A1CF /* RefCount.swift in Sources */,
+				A80F223FA8DE3EFF2B59F5356E114EBD /* RefCountDisposable.swift in Sources */,
+				2548DC0992B55BE1E01A3957E8DD6D31 /* Repeat.swift in Sources */,
+				74F5E7BE653FC92CDD229EC32CBCDFE9 /* ReplaySubject.swift in Sources */,
+				2F4CB61EB466CCEAFBC662A76FE12D81 /* RetryWhen.swift in Sources */,
+				53C9EC191E217693F417F3F3D5BD7E43 /* Rx.swift in Sources */,
+				065D3BEF76FFE3B3DF7B72302D5D7DB0 /* RxMutableBox.swift in Sources */,
+				7418514157E5C688CE763A5F254CF413 /* Sample.swift in Sources */,
+				D7500103A9FAA223279359D5F701B1CA /* Scan.swift in Sources */,
+				18F6CBEA55853D5400671FFC872FEB8D /* ScheduledDisposable.swift in Sources */,
+				C6913A7E9C0C2474F28A914401538F1E /* ScheduledItem.swift in Sources */,
+				09B3B057734A3D96C3EFDEA6F6098411 /* ScheduledItemType.swift in Sources */,
+				8E2DE5024F9792C19792D92B8B1D985D /* SchedulerServices+Emulation.swift in Sources */,
+				88FC4A07660873918F076FF438E24176 /* SchedulerType.swift in Sources */,
+				8987DC4DFACCA1F78A94D60F1EDFC99B /* Sequence.swift in Sources */,
+				0CFA33E64D14743BE85F0223890703FF /* SerialDispatchQueueScheduler.swift in Sources */,
+				CD7301609168DEDFC3736C07BA0881B1 /* SerialDisposable.swift in Sources */,
+				47C71957DC7BADC013C58987277C1BD2 /* ShareReplay1.swift in Sources */,
+				DEBACD931A5946D126B0215F2E5490E9 /* ShareReplay1WhileConnected.swift in Sources */,
+				F17C36EE5E47C26D58ACC1C16C169A83 /* SingleAssignmentDisposable.swift in Sources */,
+				F42EBA332695D4D99D6D6AE0531E8476 /* SingleAsync.swift in Sources */,
+				420B2B089843D05295392FFE1944FFC5 /* Sink.swift in Sources */,
+				01803CDE548981116E7A943E1E109A39 /* Skip.swift in Sources */,
+				D5F0C6BCB89A7D95ADDDBE8D79996573 /* SkipUntil.swift in Sources */,
+				2E0F6361F3899645D43F388A5C267D4C /* SkipWhile.swift in Sources */,
+				99275884D21412F97109A8169AAC77F4 /* StableCompositeDisposable.swift in Sources */,
+				242CF41A195F0BFA5D26BA5901A077EA /* StartWith.swift in Sources */,
+				55FD53BACDCF756892618AE87B40E110 /* String+Rx.swift in Sources */,
+				48FDC28F367EE164320F7C40A5BBEF6A /* SubjectType.swift in Sources */,
+				BDDF748143E479CF6EABE05041F7B6F2 /* SubscribeOn.swift in Sources */,
+				FF2C60939A60815A9D77688C30A55CE9 /* SubscriptionDisposable.swift in Sources */,
+				A870750758D17331ABB8C0A6FBEE9183 /* Switch.swift in Sources */,
+				815412E715BE08871E4C5ABC97006596 /* SynchronizedDisposeType.swift in Sources */,
+				D1F1D0390E73502FE5C22246171BE72B /* SynchronizedOnType.swift in Sources */,
+				566759A64E3D6143035478A562348AB4 /* SynchronizedSubscribeType.swift in Sources */,
+				0E6188767C3FAF3698E2230366164E66 /* SynchronizedUnsubscribeType.swift in Sources */,
+				3E2ECDFC62B33F044E1AF48EB320DAE1 /* TailRecursiveSink.swift in Sources */,
+				A03494739582FEBB17DA79D2920E1F7A /* Take.swift in Sources */,
+				F16FBB4B6EC68C9609A904B8BE63BA36 /* TakeLast.swift in Sources */,
+				7908C1A8D99504533AC23866832E9706 /* TakeUntil.swift in Sources */,
+				A07E4C0953ACB36A5DA675ABEDA61BB8 /* TakeWhile.swift in Sources */,
+				8FE9F9B1EC3C5A7D2D6CDAA2C4BA9BAE /* Throttle.swift in Sources */,
+				B6DFC690E7D0B1E5CADCFC3D7483685E /* Timeout.swift in Sources */,
+				F9EA78A1A667DF3843D7E1F2D6630F38 /* Timer.swift in Sources */,
+				E4DFD6E97EE78AF7AA8BA84E20C6523F /* ToArray.swift in Sources */,
+				90379C4D111C3BB8834CC117AD072DE2 /* Using.swift in Sources */,
+				8F5E62777148745FAFCD9848F2216462 /* Variable.swift in Sources */,
+				CDBD80EB63A3482BF30B876938782D2C /* VirtualTimeConverterType.swift in Sources */,
+				9594E7B489E20FA0CE16209AA0D9A33B /* VirtualTimeScheduler.swift in Sources */,
+				15F4962BEBC4BA7715C5AEABC392D477 /* Window.swift in Sources */,
+				ADD429CB6F5F9DE75256086A939119B1 /* WithLatestFrom.swift in Sources */,
+				2DDF89976DA0A48A2EEA28FFCD90E170 /* Zip+arity.swift in Sources */,
+				307539268B403C5527AD2CAC86EEF51B /* Zip+CollectionType.swift in Sources */,
+				772264D999738121516654B4232C27CA /* Zip.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6DF8079D60BBBC0561EE11B941804DC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ABB75716FC955FDA06FCD29DE6F32178 /* AddRef.swift in Sources */,
+				F0E76B087E7E5F0C0AC5AA247AB65401 /* Amb.swift in Sources */,
+				3D3655EA84BA51E653305BA5C757DEDD /* AnonymousDisposable.swift in Sources */,
+				18BB6406DBA51C04A9070E7DAE7CEA32 /* AnonymousInvocable.swift in Sources */,
+				EDD889910ED1B6E47D1D22912539C0C3 /* AnonymousObservable.swift in Sources */,
+				BAF807493CB41AC83E6E5BF2D65CA107 /* AnonymousObserver.swift in Sources */,
+				503E3338DF4E754C7E55F6C3B1E3E077 /* AnyObserver.swift in Sources */,
+				13477CD7CE62DA553A65F4E8588AC29D /* AsyncLock.swift in Sources */,
+				5C897B7691027D6EF6468F249FEF2833 /* Bag.swift in Sources */,
+				2AC4CA10BF5CA4BC515B472AEDE54445 /* BehaviorSubject.swift in Sources */,
+				F683FDBA6C4E8E68A2779E54F74078E3 /* BinaryDisposable.swift in Sources */,
+				6147FC5841082B8D142AE6914FB00B7F /* BooleanDisposable.swift in Sources */,
+				0ECA27BEBCA1AA178470104FBD0E29D6 /* Buffer.swift in Sources */,
+				BFC2B5254C88254A58C95900FBA83AA3 /* Cancelable.swift in Sources */,
+				275E8986FB7ADB3A095558F0BF433833 /* Catch.swift in Sources */,
+				12057F126FEE11DB7394DA87B1E8ED18 /* CombineLatest+arity.swift in Sources */,
+				A138EAA2EF4367C0E438246F137F7FF8 /* CombineLatest+CollectionType.swift in Sources */,
+				94253F9E40DD9BBE9F3C9329447B4968 /* CombineLatest.swift in Sources */,
+				AF73F748061BE56ED8FDF3F99D0C0803 /* CompositeDisposable.swift in Sources */,
+				8D3999B3B1E916D957A5C779A5EBB60E /* Concat.swift in Sources */,
+				7E412D4C2839AA78A37DC16806611918 /* ConcurrentDispatchQueueScheduler.swift in Sources */,
+				B8E890AC72A2B515423B0873EBA7497B /* ConcurrentMainScheduler.swift in Sources */,
+				44A9E2D9BDB77A290A874AC9B82CA058 /* ConnectableObservable.swift in Sources */,
+				EA6916A705334537CA79073B9FF7BA5C /* ConnectableObservableType.swift in Sources */,
+				85BEA7D91944470D6D27E8F8AFD5DC33 /* CurrentThreadScheduler.swift in Sources */,
+				F4BE7B053C0D4DC5F1CE34E2BD1D3C5A /* Debug.swift in Sources */,
+				0CC3868667FB42D9AE0F41894DFF9817 /* Deferred.swift in Sources */,
+				B93E360837BF6049E6ADBCB496DD486E /* DelaySubscription.swift in Sources */,
+				70395B0C308DEC6A90B53EDF20802995 /* DispatchQueueSchedulerQOS.swift in Sources */,
+				9ADA5122804C363890866E9689DC09EB /* Disposable.swift in Sources */,
+				33AEE3A4B80BC6D382A80C251AD174C3 /* DisposeBag.swift in Sources */,
+				E5748D29F9391596CDD479CA089F4E1B /* DisposeBase.swift in Sources */,
+				39BC07ED0F9C8237F0CF879CB5617181 /* DistinctUntilChanged.swift in Sources */,
+				79F67FB9CB9E17F8CBF312FA0084EAB2 /* Do.swift in Sources */,
+				C0A6FE769DB8A583B4AB4F853DCACCB8 /* ElementAt.swift in Sources */,
+				010C64612B6F3C569DD06BF294943208 /* Empty.swift in Sources */,
+				056D9D725EE24B24614AF91C4E832CE6 /* Error.swift in Sources */,
+				E3AA96F7AED9BA93194DC007ECEF5253 /* Errors.swift in Sources */,
+				AD4ED07FD9EA0B454D9798F141F5CE97 /* Event.swift in Sources */,
+				7E53E34B09E745150E50C6A324601EB6 /* Filter.swift in Sources */,
+				A7F78203B95EAC361DD6C18C24D9C6EA /* Generate.swift in Sources */,
+				625F7B91B276D9AD6E32248D4F1F4861 /* HistoricalScheduler.swift in Sources */,
+				269992A3BB1AD297195CB4C3A382DDDA /* HistoricalSchedulerTimeConverter.swift in Sources */,
+				0F6A376FDBDBE0F5EC0A5DFCA1E41EEC /* ImmediateScheduler.swift in Sources */,
+				6FD602910C6A4CCF48277C86A835C39E /* ImmediateSchedulerType.swift in Sources */,
+				6ACDA50CF7E4AA489A05B943886D1329 /* InfiniteSequence.swift in Sources */,
+				55803E192FDF33FACEB82F80810AD284 /* InvocableScheduledItem.swift in Sources */,
+				7CE43A2B274B3A1C65CA161F632448B1 /* InvocableType.swift in Sources */,
+				17744F33B9814C0F99CD9610B6F63A3C /* Just.swift in Sources */,
+				2CE57331ED99C2D3E28CC5FA7F2E489E /* Lock.swift in Sources */,
+				EE3F30ED84D01AA3F798CE0FF424F2B5 /* LockOwnerType.swift in Sources */,
+				656AF484ECD477CE254E68B0845BE284 /* MainScheduler.swift in Sources */,
+				ADC23C0C5CA9D89EC7970AEA31E22133 /* Map.swift in Sources */,
+				703A91CA61086D71F395EB4300699E18 /* Merge.swift in Sources */,
+				A5867CFCE263A489500E497E982C98B3 /* Multicast.swift in Sources */,
+				13240DAE3074045875C9BF40FA6C2D8C /* NAryDisposable.swift in Sources */,
+				381606C2C2D281EACA05C8A7EE991154 /* Never.swift in Sources */,
+				E9ED7FE4CE65BB533604E7AD81D236A5 /* NopDisposable.swift in Sources */,
+				932A608D68C76DBCD3887C0428352870 /* Observable+Aggregate.swift in Sources */,
+				F5FD8B227B68EF7C52764E8C8C81A6D1 /* Observable+Binding.swift in Sources */,
+				275FF153A051A414EE420FC3E9FB1027 /* Observable+Concurrency.swift in Sources */,
+				2C771E3DEEBCDCCD7642FFBC88F4B21A /* Observable+Creation.swift in Sources */,
+				CFCF19080BB274D8EEF1B5A844B36F5E /* Observable+Debug.swift in Sources */,
+				E78BCA5E5168C44187E2B8A479663BE2 /* Observable+Extensions.swift in Sources */,
+				8D3EEF1A053E268995FD7ED5169F02B0 /* Observable+Multiple.swift in Sources */,
+				30EA89C837F36EC0047FF48329CDB9DF /* Observable+Single.swift in Sources */,
+				83E49E67B149F9FB070BFAC545DEC15A /* Observable+StandardSequenceOperators.swift in Sources */,
+				6B702CBA3187CA6D991CBE76351837FD /* Observable+Time.swift in Sources */,
+				C7173C062C939B53E256CEE89C8C85FA /* Observable.swift in Sources */,
+				13415C7329C8E3CA1EF501EB6450CF3C /* ObservableConvertibleType.swift in Sources */,
+				04B59445A37377F5D0DF638B75676F9D /* ObservableType.swift in Sources */,
+				377230FDD0CDD270BFF84020197D953B /* ObserveOn.swift in Sources */,
+				B0A9FD2263DA835993FD907E4B4CE2C3 /* ObserveOnSerialDispatchQueue.swift in Sources */,
+				D8AB8DFEA14F6A474AAD67911ED5F9AD /* ObserverBase.swift in Sources */,
+				F6BB3FFD23B8534A7B485A347AFADAFC /* ObserverType.swift in Sources */,
+				F0EE7E6B78C9D23E8B022BD87DE056C7 /* OperationQueueScheduler.swift in Sources */,
+				569C76844EC991348E682B42B5153E23 /* Platform.Darwin.swift in Sources */,
+				7847BFC1F539128C32E132CB47172B80 /* Platform.Linux.swift in Sources */,
+				AA16F216C37B4D26B2AEBA5318F20F2B /* Pods-RxGesture_iOS_Demo-RxSwift-dummy.m in Sources */,
+				60D58A4919924C9ED9BC875A2866FBDE /* PriorityQueue.swift in Sources */,
+				E3399B666DD32E780F2CB38A337B38CD /* Producer.swift in Sources */,
+				DCBA1326E666BBBBE25A8762C87B5C3A /* PublishSubject.swift in Sources */,
+				5BFEA69A0915F6918164977C108CBBAF /* Queue.swift in Sources */,
+				5ECA4DA302151ED29AF5DAD33DF54FA4 /* Range.swift in Sources */,
+				75E7B15E4542BBAB1CFDDDBD6EA1780A /* RecursiveScheduler.swift in Sources */,
+				FF235E5B69D1AEE2514F3CE78B761139 /* Reduce.swift in Sources */,
+				2F2E1B3CE08387E078A0F574EAEF69E7 /* RefCount.swift in Sources */,
+				6A2E2C219DFF6D32C16239EE310606E8 /* RefCountDisposable.swift in Sources */,
+				FEDF1B082CA033A0952EA3E981B0A9B0 /* Repeat.swift in Sources */,
+				24D88A7B7FE5BB4A952752420717A25A /* ReplaySubject.swift in Sources */,
+				6852FC5243339B784056CB637BC1FEAC /* RetryWhen.swift in Sources */,
+				F11BBCAE8E7A90157F5AE35594336B5D /* Rx.swift in Sources */,
+				88598E8F88F0DAC9F2DA4B493925178E /* RxMutableBox.swift in Sources */,
+				5ACBDD58CF47ECD8AD16A8E21B38D22A /* Sample.swift in Sources */,
+				5DCBAB0AEE38AA2F3D5A38E87AAE9EDF /* Scan.swift in Sources */,
+				66E7C9EF14FDB3049AD6DBADD3D5F546 /* ScheduledDisposable.swift in Sources */,
+				3B396FE81D2359AEF6D965CBD9818B8F /* ScheduledItem.swift in Sources */,
+				FE7D4761ACE3A5A19A2C6CFC4C2D7DF2 /* ScheduledItemType.swift in Sources */,
+				7B78DDBD2013D33F60F929243F25B565 /* SchedulerServices+Emulation.swift in Sources */,
+				A411B27CFFCA6B4EA5F4A46033C005A5 /* SchedulerType.swift in Sources */,
+				25C05A083F477603B7EA669638EC0016 /* Sequence.swift in Sources */,
+				CCE36FB9BC39FC2DA56F7ADB0C6B04D5 /* SerialDispatchQueueScheduler.swift in Sources */,
+				DF0B0172701409E57A6201CA8FBF0574 /* SerialDisposable.swift in Sources */,
+				615ABC9784F0410A0AB3F458224F9374 /* ShareReplay1.swift in Sources */,
+				87DD8E5189D29C2A58ADF3FB7B5B0FBA /* ShareReplay1WhileConnected.swift in Sources */,
+				23150967BB721DD3EDF525D42D23C69F /* SingleAssignmentDisposable.swift in Sources */,
+				D6EDDE62751FFA62ED72081E39D6F19F /* SingleAsync.swift in Sources */,
+				8AE5D75670141C6CD6BCBD346D5587AF /* Sink.swift in Sources */,
+				AC00F08A8CDC8D49C2A4DF634C4AA16E /* Skip.swift in Sources */,
+				E57C18EEA2C6EAAAFC661CC36A08359C /* SkipUntil.swift in Sources */,
+				35A0DBDABA33B8F9D4E26D70E7FE4DA5 /* SkipWhile.swift in Sources */,
+				F1790D9553734F8D05439D4B89D6FE66 /* StableCompositeDisposable.swift in Sources */,
+				EFE9CC2266B78C141870E56568CE0A4B /* StartWith.swift in Sources */,
+				8785D32B23307F4B79618A5F7856F44F /* String+Rx.swift in Sources */,
+				106A4BA5EE50593CF0EF869952FF8DCB /* SubjectType.swift in Sources */,
+				2372E8B1408EA57F7E143EB87A85881F /* SubscribeOn.swift in Sources */,
+				2707BE20B947454620D28D8E8DC421AB /* SubscriptionDisposable.swift in Sources */,
+				E63D30C2209090D128D2266CC5779DA1 /* Switch.swift in Sources */,
+				9EC42C15F58BCE37BC88E12D6733EF4B /* SynchronizedDisposeType.swift in Sources */,
+				D8B0D36D7985B7BAAA81FB480AE40EB1 /* SynchronizedOnType.swift in Sources */,
+				89BA35490BB928E75A9CC8E7A2FA3DDA /* SynchronizedSubscribeType.swift in Sources */,
+				6AAF23825904D6DFC9229E6C7BD8CA4C /* SynchronizedUnsubscribeType.swift in Sources */,
+				8D75B23AA0082EE3BE5054DF283818F3 /* TailRecursiveSink.swift in Sources */,
+				6F1701065113278B4F9EA93F2C4D30AB /* Take.swift in Sources */,
+				AF895FF485271D550E4D064A84FB2619 /* TakeLast.swift in Sources */,
+				E1D340DC7B6235125C738489439509C4 /* TakeUntil.swift in Sources */,
+				23D44BE2351ABF5A8F0A758F9E97591D /* TakeWhile.swift in Sources */,
+				0C4F3EAA99C096AD1085CA2A48A5DC85 /* Throttle.swift in Sources */,
+				3910FCE5221CCE106E07A99766F29D92 /* Timeout.swift in Sources */,
+				B30D924AB6FBA8B2DCAC4FC1495CB45F /* Timer.swift in Sources */,
+				79AB7F257D1569817E550D4098C2E58B /* ToArray.swift in Sources */,
+				BEF4A476C5C6C876B27C5F88A81B5043 /* Using.swift in Sources */,
+				268CE435B9F2129DDA96FB23522870E4 /* Variable.swift in Sources */,
+				60E0E6A55FB93D1F65E4691E05F2047B /* VirtualTimeConverterType.swift in Sources */,
+				5282FD9C9A97C069805A7E22A42BC5A8 /* VirtualTimeScheduler.swift in Sources */,
+				721A84CDA8546C0571A414907F59A60C /* Window.swift in Sources */,
+				DDBA8228316C11F620BEC183CE24EBCC /* WithLatestFrom.swift in Sources */,
+				D9B6E88A21A5218B4346387AFDB83F3C /* Zip+arity.swift in Sources */,
+				7D929FFFFBCE37A90FDFAEDF52FBF97E /* Zip+CollectionType.swift in Sources */,
+				A4FE2267F0D28CB4EDFF93E2BEA9E8B6 /* Zip.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		086E33B335E329AF6B3E4840A5067F05 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_iOS_Demo-RxSwift";
+			target = 9B27914C2D65E7BCA3CAB1D2365E645D /* Pods-RxGesture_iOS_Demo-RxSwift */;
+			targetProxy = CA7750E5ABEF5F2B68D50415B80A5EC9 /* PBXContainerItemProxy */;
+		};
+		37DE1A019926E248B0F8C4BFA0957231 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_OSX_Demo-RxCocoa";
+			target = 9B0124864FA21CEC6CC3F9B3C55B6F65 /* Pods-RxGesture_OSX_Demo-RxCocoa */;
+			targetProxy = 9B6B4A1F1ED7FC887699E49A2A6262A4 /* PBXContainerItemProxy */;
+		};
+		847834D1DB009F49A71F9BE5F785B24B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_OSX_Demo-RxSwift";
+			target = D7D2E8A3E11B6A93694AEE6F34218DD3 /* Pods-RxGesture_OSX_Demo-RxSwift */;
+			targetProxy = 102827C3A99E45D1C6FDE5A5DBC0E68E /* PBXContainerItemProxy */;
+		};
+		8F7CCA301B616F7D8D91666A274C9185 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_iOS_Demo-RxCocoa";
+			target = 614365A9E4840470AC452C75DD2858EC /* Pods-RxGesture_iOS_Demo-RxCocoa */;
+			targetProxy = A189BB98A9127C953E6B4A32A68E859F /* PBXContainerItemProxy */;
+		};
+		9CA8E982B83600D9910D7D70B286823B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_OSX_Demo-RxGesture";
+			target = FEC7E09BE7C35F9F8658D953E429D451 /* Pods-RxGesture_OSX_Demo-RxGesture */;
+			targetProxy = EC09866E2A98A4329F1656536A729543 /* PBXContainerItemProxy */;
+		};
+		A8B8C84A3664BFD488DDAC8393D52116 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_iOS_Demo-RxCocoa";
+			target = 614365A9E4840470AC452C75DD2858EC /* Pods-RxGesture_iOS_Demo-RxCocoa */;
+			targetProxy = BAE5E5AF1B14DE4D1BBFC3E9FBBF1FC2 /* PBXContainerItemProxy */;
+		};
+		BC0F59D8DF7183BCA7D0C4C53E1BC98D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_iOS_Demo-RxSwift";
+			target = 9B27914C2D65E7BCA3CAB1D2365E645D /* Pods-RxGesture_iOS_Demo-RxSwift */;
+			targetProxy = E19FE5C08FA3F61711C410D13B756BA0 /* PBXContainerItemProxy */;
+		};
+		BC6C0360F2323A799BCA9C0911695482 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_OSX_Demo-RxCocoa";
+			target = 9B0124864FA21CEC6CC3F9B3C55B6F65 /* Pods-RxGesture_OSX_Demo-RxCocoa */;
+			targetProxy = D191CE7C858A07E1680413AC79142656 /* PBXContainerItemProxy */;
+		};
+		C381F6C0D2BF123EA57219C3E98C84C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_OSX_Demo-RxSwift";
+			target = D7D2E8A3E11B6A93694AEE6F34218DD3 /* Pods-RxGesture_OSX_Demo-RxSwift */;
+			targetProxy = 3B18CE2FF2F45E60306F01D5887056D3 /* PBXContainerItemProxy */;
+		};
+		D13E9BB839200D5CD261004AF41268D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-RxGesture_iOS_Demo-RxGesture";
+			target = FF39F572578F134BF8414A8D27FD3729 /* Pods-RxGesture_iOS_Demo-RxGesture */;
+			targetProxy = 9B45A1851F5175F17D0F160D545D2D22 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1799597E775C55C9969167456E64659A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5F73DCC6D3F37BDB0EE4D0E020E4901D /* Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = RxCocoa;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1B16C8535DFF1BF401E7610C26D5A1D9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 82A721AFC5D1B757D919FEC84F9FEF74 /* Pods-RxGesture_OSX_Demo-RxGesture.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxGesture;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1F8E6558BAC2C93227F65E3870B19264 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AFE010FEC036F74911E6F9609402C03F /* Pods-RxGesture_OSX_Demo-RxCocoa.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxCocoa;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		20618F75B2A8404B53E0916FE475229B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 97E089F34EA8E281F450990124ADE867 /* Pods-RxGesture_iOS_Demo.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo/Pods-RxGesture_iOS_Demo.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_RxGesture_iOS_Demo;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2E8AE45009EAF83A18B9DF5D362ACDDD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FE463EC4F9832060D985F73596AD1F98 /* Pods-RxGesture_iOS_Demo.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo/Pods-RxGesture_iOS_Demo.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_RxGesture_iOS_Demo;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3855C276EF7C6BB8BBDC137EA29C5AE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 969EF9A054D7A4FF9D52EC47F03E29BB /* Pods-RxGesture_OSX_Demo.debug.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo/Pods-RxGesture_OSX_Demo.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_RxGesture_OSX_Demo;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4367F29A7CAE5D22120821D3736AB6BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 82A721AFC5D1B757D919FEC84F9FEF74 /* Pods-RxGesture_OSX_Demo-RxGesture.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxGesture/Pods-RxGesture_OSX_Demo-RxGesture.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = RxGesture;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		55620F726CA0D03B143CFF89E8A6CF77 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BDB8D850932A64821E98B8CF500069E /* Pods-RxGesture_OSX_Demo.release.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo/Pods-RxGesture_OSX_Demo.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_RxGesture_OSX_Demo;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		762B97592028B0AF475F397928ADD638 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 637B39D283F2B3C1CE39F900E3526F2C /* Pods-RxGesture_OSX_Demo-RxSwift.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = RxSwift;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		76B114D443921B9C63AB12F9EE7AC8AB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 613CFDD9885D7CC54BC0041A8B2E9FE8 /* Pods-RxGesture_iOS_Demo-RxGesture.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = RxGesture;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		7BBDD3EDB691FC01479A70C69E47CEE7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F613E3B025F9B61C1CAB05CA71EA6B22 /* Pods-RxGesture_iOS_Demo-RxSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		7F089E4EA414B734ED9F56F71D01F01E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F613E3B025F9B61C1CAB05CA71EA6B22 /* Pods-RxGesture_iOS_Demo-RxSwift.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxSwift/Pods-RxGesture_iOS_Demo-RxSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = RxSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		856BEF17CF7475929D62A60D15415559 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		99BCD2A0F6991CED214B3FE26A22B907 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 613CFDD9885D7CC54BC0041A8B2E9FE8 /* Pods-RxGesture_iOS_Demo-RxGesture.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxGesture/Pods-RxGesture_iOS_Demo-RxGesture.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxGesture;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		B073BB08B89B47C6FAC0A2BC30BEB5EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AFE010FEC036F74911E6F9609402C03F /* Pods-RxGesture_OSX_Demo-RxCocoa.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxCocoa/Pods-RxGesture_OSX_Demo-RxCocoa.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = RxCocoa;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B8B9F1EB2BCB1B79E946A0A557D77AB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 637B39D283F2B3C1CE39F900E3526F2C /* Pods-RxGesture_OSX_Demo-RxSwift.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_OSX_Demo-RxSwift/Pods-RxGesture_OSX_Demo-RxSwift.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxSwift;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		CD4013CD18B320C79647E2D4EA37E582 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		E647F4CE6EFA1262239A58D3F8795293 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5F73DCC6D3F37BDB0EE4D0E020E4901D /* Pods-RxGesture_iOS_Demo-RxCocoa.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-RxGesture_iOS_Demo-RxCocoa/Pods-RxGesture_iOS_Demo-RxCocoa.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = RxCocoa;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2A940E69BC5371EEA2C7CCEACA25AB6C /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo-RxGesture" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4367F29A7CAE5D22120821D3736AB6BB /* Debug */,
+				1B16C8535DFF1BF401E7610C26D5A1D9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD4013CD18B320C79647E2D4EA37E582 /* Debug */,
+				856BEF17CF7475929D62A60D15415559 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		54F425529CB9BBD2E9204457CDBE6EBE /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3855C276EF7C6BB8BBDC137EA29C5AE3 /* Debug */,
+				55620F726CA0D03B143CFF89E8A6CF77 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6D7B567D2F85E5F4E1BEA8ECF23B62CC /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo-RxSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				762B97592028B0AF475F397928ADD638 /* Debug */,
+				B8B9F1EB2BCB1B79E946A0A557D77AB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77A85EF82F6A93E9EBFCD97A800D30F0 /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo-RxGesture" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				76B114D443921B9C63AB12F9EE7AC8AB /* Debug */,
+				99BCD2A0F6991CED214B3FE26A22B907 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9D33872BAF4DC5FEC16683ED5494A07A /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				20618F75B2A8404B53E0916FE475229B /* Debug */,
+				2E8AE45009EAF83A18B9DF5D362ACDDD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C87E6CC572B39715080A5C3C3D52AA7F /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo-RxSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7F089E4EA414B734ED9F56F71D01F01E /* Debug */,
+				7BBDD3EDB691FC01479A70C69E47CEE7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FF12F2A0C3DB5BC71502F2741134C221 /* Build configuration list for PBXNativeTarget "Pods-RxGesture_OSX_Demo-RxCocoa" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B073BB08B89B47C6FAC0A2BC30BEB5EC /* Debug */,
+				1F8E6558BAC2C93227F65E3870B19264 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FFE6FFDA3FB700D8A1F431F6BE633F21 /* Build configuration list for PBXNativeTarget "Pods-RxGesture_iOS_Demo-RxCocoa" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1799597E775C55C9969167456E64659A /* Debug */,
+				E647F4CE6EFA1262239A58D3F8795293 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+}

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Pod/Classes/LongPressConfig.swift
+++ b/Pod/Classes/LongPressConfig.swift
@@ -1,0 +1,50 @@
+// Copyright (c) RxSwiftCommunity
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import CoreGraphics
+
+public struct LongPressConfig {
+    public enum Type {
+        case Began, Changed, Ended, Any
+    }
+    
+    public let location: CGPoint
+    
+    public let type: Type
+    public var recognizer: AnyObject?
+    
+    public static let Began: LongPressConfig = {
+        return LongPressConfig(location: .zero, type: .Began, recognizer: nil)
+    }()
+    
+    public static let Changed: LongPressConfig = {
+        return LongPressConfig(location: .zero, type: .Changed, recognizer: nil)
+    }()
+    
+    public static let Ended: LongPressConfig = {
+        return LongPressConfig(location: .zero, type: .Ended, recognizer: nil)
+    }()
+    
+    public static let Any: LongPressConfig = {
+        return LongPressConfig(location: .zero, type: .Any, recognizer: nil)
+    }()
+
+}

--- a/Pod/Classes/LongPressConfig.swift
+++ b/Pod/Classes/LongPressConfig.swift
@@ -26,7 +26,11 @@ public struct LongPressConfig {
         case Began, Changed, Ended, Any
     }
     
+    #if os(iOS)
     public let location: CGPoint
+    #elseif os(OSX)
+    public let location: NSPoint
+    #endif
     
     public let type: Type
     public var recognizer: AnyObject?

--- a/Pod/Classes/PanConfig.swift
+++ b/Pod/Classes/PanConfig.swift
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import CoreGraphics
 
 public struct PanConfig {
     public enum Type {

--- a/Pod/Classes/RotateConfig.swift
+++ b/Pod/Classes/RotateConfig.swift
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import CoreGraphics
 
 public struct RotateConfig {
     public enum Type {

--- a/Pod/Classes/RxGesture.swift
+++ b/Pod/Classes/RxGesture.swift
@@ -28,8 +28,8 @@ public enum RxGestureTypeOption: Equatable {
     case Tap
     case SwipeLeft, SwipeRight, SwipeUp, SwipeDown
     case LongPress
-    case TargetTap(TapConfig)
-    case TargetLongPress(LongPressConfig)
+    case LocatedTap(TapConfig)
+    case LocatedLongPress(LongPressConfig)
     
     //: Shared gestures
     case Pan(PanConfig)
@@ -41,7 +41,7 @@ public enum RxGestureTypeOption: Equatable {
     public static func all() -> [RxGestureTypeOption] {
         return [
             .Tap, .SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown, .LongPress,
-            .TargetTap(.Anywhere), TargetLongPress(.Any), .Pan(.Any), Rotate(.Any),
+            .LocatedTap(.Anywhere), .LocatedLongPress(.Any), .Pan(.Any), Rotate(.Any),
             .Click, .RightClick
         ]
     }
@@ -56,8 +56,8 @@ public func ==(lhs: RxGestureTypeOption, rhs: RxGestureTypeOption) -> Bool {
     case (.SwipeUp, .SwipeUp): fallthrough
     case (.SwipeDown, .SwipeDown): fallthrough
     case (.LongPress, .LongPress): fallthrough
-    case (.TargetTap, .TargetTap): fallthrough
-    case (.TargetLongPress, .TargetLongPress): fallthrough
+    case (.LocatedTap, .LocatedTap): fallthrough
+    case (.LocatedLongPress, .LocatedLongPress): fallthrough
     case (.Pan, .Pan): fallthrough
     case (.Rotate, .Rotate): fallthrough
     case (.Click, .Click): fallthrough

--- a/Pod/Classes/RxGesture.swift
+++ b/Pod/Classes/RxGesture.swift
@@ -28,6 +28,8 @@ public enum RxGestureTypeOption: Equatable {
     case Tap
     case SwipeLeft, SwipeRight, SwipeUp, SwipeDown
     case LongPress
+    case TargetTap(TapConfig)
+    case TargetLongPress(TapConfig)
     
     //: Shared gestures
     case Pan(PanConfig)
@@ -38,7 +40,8 @@ public enum RxGestureTypeOption: Equatable {
     
     public static func all() -> [RxGestureTypeOption] {
         return [
-            .Tap, .SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown, .LongPress, .Pan(.Any), Rotate(.Any),
+            .Tap, .SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown, .LongPress,
+            .TargetTap(.Anywhere), TargetLongPress(.Anywhere), .Pan(.Any), Rotate(.Any),
             .Click, .RightClick
         ]
     }
@@ -53,6 +56,8 @@ public func ==(lhs: RxGestureTypeOption, rhs: RxGestureTypeOption) -> Bool {
     case (.SwipeUp, .SwipeUp): fallthrough
     case (.SwipeDown, .SwipeDown): fallthrough
     case (.LongPress, .LongPress): fallthrough
+    case (.TargetTap, .TargetTap): fallthrough
+    case (.TargetLongPress, .TargetLongPress): fallthrough
     case (.Pan, .Pan): fallthrough
     case (.Rotate, .Rotate): fallthrough
     case (.Click, .Click): fallthrough

--- a/Pod/Classes/RxGesture.swift
+++ b/Pod/Classes/RxGesture.swift
@@ -29,7 +29,7 @@ public enum RxGestureTypeOption: Equatable {
     case SwipeLeft, SwipeRight, SwipeUp, SwipeDown
     case LongPress
     case TargetTap(TapConfig)
-    case TargetLongPress(TapConfig)
+    case TargetLongPress(LongPressConfig)
     
     //: Shared gestures
     case Pan(PanConfig)
@@ -41,7 +41,7 @@ public enum RxGestureTypeOption: Equatable {
     public static func all() -> [RxGestureTypeOption] {
         return [
             .Tap, .SwipeLeft, .SwipeRight, .SwipeUp, .SwipeDown, .LongPress,
-            .TargetTap(.Anywhere), TargetLongPress(.Anywhere), .Pan(.Any), Rotate(.Any),
+            .TargetTap(.Anywhere), TargetLongPress(.Any), .Pan(.Any), Rotate(.Any),
             .Click, .RightClick
         ]
     }

--- a/Pod/Classes/TapConfig.swift
+++ b/Pod/Classes/TapConfig.swift
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import CoreGraphics
 
 public struct TapConfig {
     public enum Type {

--- a/Pod/Classes/TapConfig.swift
+++ b/Pod/Classes/TapConfig.swift
@@ -1,0 +1,39 @@
+// Copyright (c) RxSwiftCommunity
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+public struct TapConfig {
+    public enum Type {
+        case Anywhere
+    }
+    
+    #if os(iOS)
+    public let location: CGPoint
+    #elseif os(OSX)
+    public let location: NSPoint
+    #endif
+    
+    public var recognizer: AnyObject?
+    
+    public static let Anywhere: TapConfig = {
+        return TapConfig(location: .zero, recognizer: nil)
+    }()
+}

--- a/Pod/Classes/iOS/UIView+RxGesture.swift
+++ b/Pod/Classes/iOS/UIView+RxGesture.swift
@@ -83,6 +83,55 @@ extension UIView {
                 )
             }
             
+            // target taps
+            if type.contains(.TargetTap(.Anywhere)) {
+                let tap = UITapGestureRecognizer()
+                control.addGestureRecognizer(tap)
+                
+                let targetTapEvent = tap.rx_event.shareReplay(1).map {[weak self] recognizer -> RxGestureTypeOption in
+                    let recognizer = recognizer as! UITapGestureRecognizer
+                    
+                    //current values
+                    let newConfig = TapConfig(
+                        location: recognizer.locationInView(self?.superview),
+                        recognizer: recognizer)
+                    return RxGestureTypeOption.TargetTap(newConfig)
+                }
+                
+                gestures.append(
+                    (tap, targetTapEvent.bindNext(observer.onNext))
+                )
+            }
+            
+            // target long press
+            if type.contains(.LongPress) {
+
+                //create or find existing recognizer
+                var press: UILongPressGestureRecognizer
+                
+                if let existingPress = self?.gestureRecognizers?.filter({ $0 is UILongPressGestureRecognizer }).first as? UILongPressGestureRecognizer {
+                    press = existingPress
+                } else {
+                    press = UILongPressGestureRecognizer()
+                    control.addGestureRecognizer(press)
+                }
+
+                
+                let targetPressEvent = press.rx_event.shareReplay(1).map {[weak self] recognizer -> RxGestureTypeOption in
+                    let recognizer = recognizer as! UILongPressGestureRecognizer
+                    
+                    //current values
+                    let newConfig = TapConfig(
+                        location: recognizer.locationInView(self?.superview),
+                        recognizer: recognizer)
+                    return RxGestureTypeOption.TargetTap(newConfig)
+                }
+                
+                gestures.append(
+                    (press, targetPressEvent.bindNext(observer.onNext))
+                )
+            }
+            
             //panning
             if type.contains(.Pan(.Any)) {
                 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ On __iOS__ RXGesture supports:
  - .Tap
  - .SwipeLeft, SwipeRight, SwipeUp, SwipeDown
  - .LongPress
+ - .TargetTap(.Anywhere)
+ - .TargetLongPress(.Began), .TargetLongPress(.Changed), .TargetLongPress(.Ended), .TargetLongPress(.Any)
  - .Pan(.Began), .Pan(.Changed), .Pan(.Ended), .Pan(.Any)
  - .Rotate(.Began), .Rotate(.Changed), .Rotate(.Ended), .Rotate(.Any)
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ On __iOS__ RXGesture supports:
  - .Tap
  - .SwipeLeft, SwipeRight, SwipeUp, SwipeDown
  - .LongPress
- - .TargetTap(.Anywhere)
- - .TargetLongPress(.Began), .TargetLongPress(.Changed), .TargetLongPress(.Ended), .TargetLongPress(.Any)
+ - .LocatedTap(.Anywhere)
+ - .LocatedLongPress(.Began), .LocatedLongPress(.Changed), .LocatedLongPress(.Ended), .LocatedLongPress(.Any)
  - .Pan(.Began), .Pan(.Changed), .Pan(.Ended), .Pan(.Any)
  - .Rotate(.Began), .Rotate(.Changed), .Rotate(.Ended), .Rotate(.Any)
 
@@ -57,9 +57,28 @@ myView.rx_gesture(.Tap, .Click).subscribeNext {...}
 
 to observe for the concrete gesture on each platform.
 
-## Continuous gestures
+## Continuous & detailed gestures
 
 Some recognizers fire a single event per gesture and don't provide any values. For example `.Tap` just lets you know a view has been tapped - that's all.
+
+On the other hand, `.LocatedTap` reveals where exactly the tap was. Consider the following example:
+
+```swift
+squareView.rx_gesture(.LocatedTap(.Anywhere))
+    .subscribeNext { gesture in
+        switch gesture {
+        case .TargetTap(let data):
+            print(data.location) // prints location of the tap in squareView
+            break
+        default: 
+            break
+        }
+    }
+    .addDisposableTo(bag)
+```
+
+There, if `squareView` is 100x100, and `data.location` is around `(0;0)`, then the tap was approximately in the top-left corner. Respectively, `(100;100)` point is located in the bottom-right corner of the `squareView`.
+Same applies to the `.LocatedLongPress`, but there is a possibility to know where the user starts to hold the finger (`.LocatedLongPress(.Began)`), how he moves it (`.LocatedLongPress(.Changed)`), and where he ends the gesture (`.LocatedLongPress(.Ended)`). 
 
 Other recognizers provide details about the gesture (that also might be ongoing). For example the pan gesture will continuously provide you with the offset from the initial point where the gesture started:
 


### PR DESCRIPTION
I added `.targetTap` and `.targetLongPress` events. This events supplement `.tap` and `.longPress` events, but also they hold location in view where the event was fired.

So, `.targetTap` works as follows:

``` swift
hoursContainer.rx_gesture(.TargetTap(.Anywhere))
    .subscribeNext { gesture in
        switch gesture {
        case .TargetTap(let data):
            print(data.location) // prints location of the tap in hoursContainer view
            break
        default: break
        }
    }
    .addDisposableTo(bag)
```

As for `.targetLongPress`, there are `.Any`, `.Began`, `.Changed`, `.Ended` states as they are in `Pan` or `Rotate` events.

``` swift
hoursContainer.rx_gesture(.TargetLongPress(.Began), .TargetLongPress(.Ended))
    .subscribeNext { (gesture) in
        switch gesture {
        case .TargetLongPress(let data):
            print(data.location) // prints coordinates of location where user started to hold his finger and finally released
            break
        default:
            break
        }
    }
    .addDisposableTo(bag)
```

I think this will be useful when user creates a custom view with specific logic.
