### PR TITLE
Changed the deprecated 'AnonymousDisposable' for 'Disposables.create'

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,8 +3,8 @@ use_frameworks!
 
 target 'RxGesture_iOS_Demo' do
     platform :ios, '8.3'
-    pod 'RxSwift', '~> 3.0.0-beta.2'
-    pod 'RxCocoa', '~> 3.0.0-beta.2'
+    pod 'RxSwift', '~> 3.0.0'
+    pod 'RxCocoa', '~> 3.0.0'
     pod 'RxGesture', :path => '../'
 end
 

--- a/Pod/Classes/iOS/UIView+RxGesture.swift
+++ b/Pod/Classes/iOS/UIView+RxGesture.swift
@@ -195,7 +195,7 @@ extension Reactive where Base: UIView {
             }
             
             //dispose gestures
-            return AnonymousDisposable {
+            return Disposables.create {
                 for (recognizer, gesture) in gestures {
                     if let recognizer = recognizer {
                         control.removeGestureRecognizer(recognizer)

--- a/RxGesture.podspec
+++ b/RxGesture.podspec
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
   s.ios.source_files      = 'Pod/Classes/iOS/*.swift'
   s.osx.source_files      = 'Pod/Classes/OSX/*.swift'
   
-  s.dependency 'RxSwift', '~> 3.0.0-beta.2'
-  s.dependency 'RxCocoa', '~> 3.0.0-beta.2'
+  s.dependency 'RxSwift', '~> 3.0.0'
+  s.dependency 'RxCocoa', '~> 3.0.0'
   
 end
 


### PR DESCRIPTION
The last (and in production) version of RxSwift same Disposables are deprecated. After upgrade the pod for the last version, RxGesture stop to work. 
