### PR TITLE
Fixed: PanObservable didn't filter velocity

### DIFF
--- a/Pod/Classes/OSX/NSView+RxGesture.swift
+++ b/Pod/Classes/OSX/NSView+RxGesture.swift
@@ -125,7 +125,7 @@ extension Reactive where Base: NSView {
                                 switch gesture {
                                 case (.pan(let values)):
                                     return (values.translation.x >= config.translation.x || values.translation.y >= config.translation.y)
-                                        && (values.translation.x >= config.translation.x || values.translation.y >= config.translation.y)
+                                        && (values.velocity.x >= config.velocity.x || values.velocity.y >= config.velocity.y)
                                 default: return false
                                 }
                             }

--- a/Pod/Classes/iOS/UIView+RxGesture.swift
+++ b/Pod/Classes/iOS/UIView+RxGesture.swift
@@ -138,7 +138,7 @@ extension Reactive where Base: UIView {
                                 switch gesture {
                                 case (.pan(let values)):
                                     return (values.translation.x >= config.translation.x || values.translation.y >= config.translation.y)
-                                        && (values.translation.x >= config.translation.x || values.translation.y >= config.translation.y)
+                                        && (values.velocity.x >= config.velocity.x || values.velocity.y >= config.velocity.y)
                                 default: return false
                                 }
                             }


### PR DESCRIPTION
This might be a copy-paste mistake,  we check twice
`(values.translation.x >= config.translation.x || values.translation.y >= config.translation.y)`
 which is useless.

And the velocity filter is not handled anywhere !
Cheers.