### PR TITLE
ExclusiveGestureRecognizerDelegate

### DIFF
--- a/Pod/Classes/ExclusiveGestureRecognizerDelegate.swift
+++ b/Pod/Classes/ExclusiveGestureRecognizerDelegate.swift
@@ -1,0 +1,34 @@
+// Copyright (c) RxSwiftCommunity
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import RxSwift
+import RxCocoa
+
+final class ExclusiveGestureRecognizerDelegate: NSObject, GestureRecognizerDelegate {
+    
+    static let shared = ExclusiveGestureRecognizerDelegate()
+    
+    func gestureRecognizer(
+        _ gestureRecognizer: GestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: GestureRecognizer
+        ) -> Bool {
+        return false
+    }
+}

--- a/Pod/Classes/ExclusiveGestureRecognizerDelegate.swift
+++ b/Pod/Classes/ExclusiveGestureRecognizerDelegate.swift
@@ -21,14 +21,11 @@
 import RxSwift
 import RxCocoa
 
-final class ExclusiveGestureRecognizerDelegate: NSObject, GestureRecognizerDelegate {
+public final class ExclusiveGestureRecognizerDelegate: NSObject, GestureRecognizerDelegate {
     
-    static let shared = ExclusiveGestureRecognizerDelegate()
+    public static let shared = ExclusiveGestureRecognizerDelegate()
     
-    func gestureRecognizer(
-        _ gestureRecognizer: GestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: GestureRecognizer
-        ) -> Bool {
+    public func gestureRecognizer(_ gestureRecognizer: GestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: GestureRecognizer) -> Bool {
         return false
     }
 }


### PR DESCRIPTION
I had an issue similar to #42 and needed an alternative to the default `PermissiveGestureRecognizerDelegate`. I though it would be useful to have this implementation in the pod for easy reuse.