### PR TITLE
Add basic SwiftPM manifest file for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,13 @@ let package = Package(
     products: [
         .library(name: "RxGesture", targets: ["RxGesture"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.4.0")),
+    ],
     targets: [
         .target(
             name: "RxGesture",
+            dependencies: ["RxSwift", "RxCocoa"],
             path: "Pod",
             exclude: ["Pod/Classes/OSX"]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "RxGesture",
+    products: [
+        .library(name: "RxGesture", targets: ["RxGesture"])
+    ],
+    targets: [
+        .target(
+            name: "RxGesture",
+            path: "Pod",
+            exclude: ["Pod/Classes/OSX"]
+        )
+    ]
+)


### PR DESCRIPTION
This adds a very basic [SwiftPM](https://github.com/apple/swift-package-manager) manifest file to be compatible with any dependency manager that uses Apples official way of specifying libraries.

Note that I created this PR because there is already such a dependency manager: [Accio](https://github.com/JamitLabs/Accio) intends to fix several issues with Carthage and fill the gap between now and the time, when Apple adds official support for SwiftPM into Xcode. Merging this will also prepare for that bright future.