### PR TITLE
WIP: SCNView memory leak issue

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -16,3 +16,15 @@ target 'RxGesture_OSX_Demo' do
     platform :osx, '10.10'
     commonDependencies
 end
+
+post_install do |installer|
+   installer.pods_project.targets.each do |target|
+      if target.name == 'RxSwift'
+         target.build_configurations.each do |config|
+            if config.name == 'Debug'
+               config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['-D', 'TRACE_RESOURCES']
+            end
+         end
+      end
+   end
+end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - RxCocoa (5.0.0):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
-  - RxGesture (3.0.0):
+  - RxGesture (3.0.1):
     - RxCocoa (~> 5.0)
     - RxSwift (~> 5.0)
   - RxRelay (5.0.0):
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
-  RxGesture: 0cd8e37ff9a266e1c31f46bcaed6de1c536bc81e
+  RxGesture: a3f8dd6adf078110ed5e1c9c30d09d705a09852e
   RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
   RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
 
-PODFILE CHECKSUM: a8cc21e089344ff9252f7f3ac8d5361ebffc1d6d
+PODFILE CHECKSUM: 1b87df77b5c88495f1ea8ed7d6d1bebb2704f198
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.3

--- a/RxGesture/RxGesture-iOS-Tests/RxGestureTest.swift
+++ b/RxGesture/RxGesture-iOS-Tests/RxGestureTest.swift
@@ -1,0 +1,50 @@
+//
+//  RxGestureTest.swift
+//  RxGesture-iOS-Tests
+//
+//  Created by Anton Nazarov on 06/07/2019.
+//  Copyright © 2019 RxSwiftCommunity. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import Foundation
+
+class RxGestureTest: XCTestCase {
+    private var startResourceCount: Int32 = 0
+
+    override func setUp() {
+        super.setUp()
+        setUpActions()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        tearDownActions()
+    }
+}
+
+// MARK: - Private
+private extension RxGestureTest {
+    func setUpActions(){
+        _ = Hooks.defaultErrorHandler
+        _ = Hooks.customCaptureSubscriptionCallstack
+        self.startResourceCount = Resources.total
+    }
+
+    func tearDownActions() {
+        for _ in 0..<30 {
+            if self.startResourceCount < Resources.total {
+                // main schedulers need to finish work
+                print("Waiting for resource cleanup ...")
+                let mode = RunLoop.Mode.default
+                RunLoop.current.run(mode: mode, before: Date(timeIntervalSinceNow: 0.05))
+            }
+            else {
+                break
+            }
+        }
+
+        XCTAssertEqual(startResourceCount, Resources.total)
+    }
+}

--- a/RxGesture/RxGesture-iOS-Tests/RxGestureTests.swift
+++ b/RxGesture/RxGesture-iOS-Tests/RxGestureTests.swift
@@ -12,9 +12,10 @@ import RxSwift
 import RxCocoa
 import RxTest
 import RxBlocking
+import SceneKit
 @testable import RxGesture
 
-class RxGestureTests: XCTestCase {
+class RxGestureTests: RxGestureTest {
 
     var disposeBag: DisposeBag!
     var view: UIView!
@@ -28,10 +29,10 @@ class RxGestureTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         disposeBag = nil
         view = nil
         gesture = nil
+        super.tearDown()
     }
 
     func testObservable() {
@@ -61,4 +62,19 @@ class RxGestureTests: XCTestCase {
         }
     }
 
+    func testMemoryLeak() {
+        _ = TestViewController()
+    }
+}
+
+// MARK: - Private
+private extension RxGestureTest {
+    final class TestViewController {
+        private let scnView = SCNView()
+        private let disposeBag = DisposeBag()
+
+        init() {
+            scnView.rx.tapGesture().when(.recognized).subscribe().disposed(by: disposeBag)
+        }
+    }
 }

--- a/RxGesture/RxGesture.xcodeproj/project.pbxproj
+++ b/RxGesture/RxGesture.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		78FCA3A222D08A7B0022018E /* RxGestureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78FCA3A122D08A7B0022018E /* RxGestureTest.swift */; };
 		874DD3DD1FAD067200A61D4F /* GestureRecognizer+RxGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874DD3DC1FAD067200A61D4F /* GestureRecognizer+RxGesture.swift */; };
 		874DD3DE1FAD067200A61D4F /* GestureRecognizer+RxGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874DD3DC1FAD067200A61D4F /* GestureRecognizer+RxGesture.swift */; };
 		874DD3E11FAD068500A61D4F /* ForceTouchGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874DD3DF1FAD068500A61D4F /* ForceTouchGestureRecognizer.swift */; };
@@ -61,6 +62,7 @@
 
 /* Begin PBXFileReference section */
 		06002C42227C208400C7FBDD /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = ../Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
+		78FCA3A122D08A7B0022018E /* RxGestureTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxGestureTest.swift; sourceTree = "<group>"; };
 		874DD3DC1FAD067200A61D4F /* GestureRecognizer+RxGesture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GestureRecognizer+RxGesture.swift"; sourceTree = "<group>"; };
 		874DD3DF1FAD068500A61D4F /* ForceTouchGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceTouchGestureRecognizer.swift; sourceTree = "<group>"; };
 		874DD3E01FAD068500A61D4F /* TouchDownGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TouchDownGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 			children = (
 				87AF2B5F1FAF1D3E0002FC29 /* RxGestureTests.swift */,
 				874DD3EB1FAD0F7D00A61D4F /* Info.plist */,
+				78FCA3A122D08A7B0022018E /* RxGestureTest.swift */,
 			);
 			path = "RxGesture-iOS-Tests";
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				87AF2B601FAF1D3E0002FC29 /* RxGestureTests.swift in Sources */,
+				78FCA3A222D08A7B0022018E /* RxGestureTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,9 +496,10 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxGesture-iOS-Tests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks /Users/antonnazarov/Projects/RxGesture/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = RxSwiftCommunity.RxGesture.iOS.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -515,9 +520,10 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxGesture-iOS-Tests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks /Users/antonnazarov/Projects/RxGesture/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = RxSwiftCommunity.RxGesture.iOS.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -703,9 +709,11 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = RxSwiftCommunity.RxGesture.iOS;
 				PRODUCT_NAME = RxGesture;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};


### PR DESCRIPTION
Use `carthage update --no-use-binaries --configuration Debug RxSwift` to install RxSwift in tracing resources mode.
Run tests and see `4` resources are not being deallocated.

This raw iOS code with `SCNView`  is also failing. It looks like SCNView doesn't free added gestures:
```swift
var wasDeallocated = false
class MyGestureRecognizer: UIGestureRecognizer {
    deinit { wasDeallocated = true }
}

class Foo {
    let scnView = SCNView() // test passes if change to `UIView()`

    init() {
        scnView.addGestureRecognizer(MyGestureRecognizer(target: self, action: #selector(test)))
    }

    @objc func test() { }
}

final class Test: XCTestCase {
    func testMemoryLeak() {
        autoreleasepool {
            _ = Foo()
        }
        XCTAssertTrue(wasDeallocated)
    }
}
```

However, it can be fixed with adding these lines to `Foo`:
```swift
deinit {
  scnView.gestureRecognizers = nil
}
```

Sadly, fix doesn't work with Rx wrapper. I will try to investigate, however, any help will be appreciated.
I created Radar, but you know... Radars :)  https://openradar.appspot.com/radar?id=4931428085137408
