### PR TITLE
Change the default value of simultaneousRecognitionPolicy to .never

### DIFF
--- a/Pod/Classes/RxGestureRecognizerDelegate.swift
+++ b/Pod/Classes/RxGestureRecognizerDelegate.swift
@@ -68,7 +68,7 @@ public final class RxGestureRecognizerDelegate: NSObject, GestureRecognizerDeleg
     public var otherFailureRequirementPolicy: GestureRecognizerDelegatePolicy<(GestureRecognizer, GestureRecognizer)> = .never
 
     /// Corresponding delegate method: gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)
-    public var simultaneousRecognitionPolicy: GestureRecognizerDelegatePolicy<(GestureRecognizer, GestureRecognizer)> = .always
+    public var simultaneousRecognitionPolicy: GestureRecognizerDelegatePolicy<(GestureRecognizer, GestureRecognizer)> = .never
 
     #if os(iOS)
     // Workaround because we can't have stored properties with @available annotation

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ pressReceptionPolicy          -> gestureRecognizer(_:shouldReceive:) // iOS only
 This delegate can be customized in the configuration closure:
 ```swift
 view.rx.tapGesture(configuration: { gestureRecognizer, delegate in
-  delegate.simultaneousRecognitionPolicy = .always // (default value)
+  delegate.simultaneousRecognitionPolicy = .never // (default value)
   // or
-  delegate.simultaneousRecognitionPolicy = .never
+  delegate.simultaneousRecognitionPolicy = .always
   // or
   delegate.simultaneousRecognitionPolicy = .custom { gestureRecognizer, otherGestureRecognizer in
     return otherGestureRecognizer is UIPanGestureRecognizer


### PR DESCRIPTION
The default value of `RxGestureRecognizerDelegate.simultaneousRecognitionPolicy` should be `.never`, because the default implementation of corresponding delegate method: `gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)` returns false.
https://developer.apple.com/documentation/uikit/uigesturerecognizerdelegate/1624208-gesturerecognizer