### PR TITLE
Support building for catalyst.

### DIFF
--- a/Pod/Classes/OSX/NSClickGestureRecognizer+RxGesture.swift
+++ b/Pod/Classes/OSX/NSClickGestureRecognizer+RxGesture.swift
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import RxSwift
 import RxCocoa

--- a/Pod/Classes/OSX/NSGestureRecognizer+Rx.swift
+++ b/Pod/Classes/OSX/NSGestureRecognizer+Rx.swift
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import RxSwift
 import RxCocoa

--- a/Pod/Classes/OSX/NSMagnificationGestureRecognizer+RxGesture.swift
+++ b/Pod/Classes/OSX/NSMagnificationGestureRecognizer+RxGesture.swift
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import RxSwift
 import RxCocoa

--- a/Pod/Classes/OSX/NSPanGestureRecognizer+RxGesture.swift
+++ b/Pod/Classes/OSX/NSPanGestureRecognizer+RxGesture.swift
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import RxSwift
 import RxCocoa

--- a/Pod/Classes/OSX/NSPressGestureRecognizer+RxGesture.swift
+++ b/Pod/Classes/OSX/NSPressGestureRecognizer+RxGesture.swift
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import RxSwift
 import RxCocoa

--- a/Pod/Classes/OSX/NSRotationGestureRecognizer+RxGesture.swift
+++ b/Pod/Classes/OSX/NSRotationGestureRecognizer+RxGesture.swift
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import RxSwift
 import RxCocoa


### PR DESCRIPTION
This change excludes NSxxxGestureRecognizer files when building a Mac app using catalyst.