### PR TITLE
Fix broken path in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             name: "RxGesture",
             dependencies: ["RxSwift", "RxCocoa"],
             path: "Pod",
-            exclude: ["Pod/Classes/OSX"]
+            exclude: ["Classes/OSX"]
         )
     ]
 )


### PR DESCRIPTION
Fixed a broken path in `Package.swift` causing an Xcode 13 warning about a missing file.